### PR TITLE
fix: espace trop large entre "Emprunté par" ou "Prêté à" et le nom de l'emprunteur

### DIFF
--- a/templates/equipment/index.html.twig
+++ b/templates/equipment/index.html.twig
@@ -113,14 +113,12 @@
 
 								<td class="px-5 py-4">
 								{% if borrowerClub %}
-									<span class="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
-										Prêté à
-										<span class="font-semibold">{{ borrowerClub.name }}</span>
+									<span class="rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
+										Prêté à <span class="font-semibold">{{ borrowerClub.name }}</span>
 									</span>
 								{% elseif borrowerMember %}
-									<span class="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
-										Emprunté par
-										<span class="font-semibold">{{ borrowerMember.fullName }}</span>
+									<span class="rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
+										Emprunté par <span class="font-semibold">{{ borrowerMember.fullName }}</span>
 									</span>
 								{% else %}
 									<span class="inline-flex items-center rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-800">

--- a/templates/equipment/show.html.twig
+++ b/templates/equipment/show.html.twig
@@ -128,11 +128,11 @@
               <dt class="text-xs font-medium text-">Statut</dt>
               <dd class="mt-2">
                 {% if equipment.borrowerClub %}
-                  <span class="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
+                  <span class="rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
                     Prêté à <span class="font-semibold">{{ equipment.borrowerClub.name }}</span>
                   </span>
                 {% elseif equipment.borrowerMember %}
-                  <span class="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
+                  <span class="rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
                     Emprunté par <span class="font-semibold">{{ equipment.borrowerMember.fullName }}</span>
                   </span>
                 {% else %}

--- a/templates/qr_code/show.html.twig
+++ b/templates/qr_code/show.html.twig
@@ -72,7 +72,7 @@
                 <dt class="text-xs font-medium text-kyudo-gm-grey">Statut</dt>
                 <dd class="mt-2">
                   {% if equipment.borrowerClub %}
-                    <span class="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
+                    <span class="rounded-full bg-amber-50 px-3 py-1 text-xs font-medium text-amber-800">
                       Prêté à <span class="font-semibold">{{ equipment.borrowerClub.name }}</span>
                     </span>
                   {% else %}


### PR DESCRIPTION
# Description
Résout #52 