### PR TITLE
fix: utilisation traductions pour les types d'équipements + réduction espace entre pillule de propriétaire et le nom

### DIFF
--- a/templates/equipment/index.html.twig
+++ b/templates/equipment/index.html.twig
@@ -95,7 +95,7 @@
 								<td class="px-5 py-4 text-kyudo-gm-grey">{{ equipment.id }}</td>
 
 								<td class="px-5 py-4">
-									<div class="font-semibold text-kyudo-gm-dark">{{ equipment.typeName }}</div>
+									<div class="font-semibold text-kyudo-gm-dark">{{ equipment.type.label|trans }}</div>
 									<div class="mt-0.5 text-xs text-">Équipement de Kyudo</div>
 								</td>
 

--- a/templates/equipment/show.html.twig
+++ b/templates/equipment/show.html.twig
@@ -10,7 +10,7 @@
         <div>
           <div class="text-sm font-medium text-">Équipement</div>
           <h1 class="mt-1 text-3xl font-semibold tracking-tight text-kyudo-gm-dark">
-            #{{ equipment.id }} - {{ equipment.typeName }}
+            #{{ equipment.id }} - {{ equipment.type.label|trans }}
           </h1>
           <p class="mt-1 text-kyudo-gm-grey">Propriétaire et emprunteur actuel.</p>
         </div>
@@ -46,22 +46,22 @@
 
             <div class="rounded-2xl bg-kyudo-gm-light-grey p-4">
               <dt class="text-xs font-medium text-">Type</dt>
-              <dd class="mt-1 text-sm font-semibold text-kyudo-gm-dark">{{ equipment.typeName }}</dd>
+              <dd class="mt-1 text-sm font-semibold text-kyudo-gm-dark">{{ equipment.type.label|trans }}</dd>
             </div>
 
             <div class="rounded-2xl bg-kyudo-gm-light-grey p-4 sm:col-span-2">
               <dt class="text-xs font-medium text-">Propriétaire</dt>
-              <dd class="mt-1 flex flex-wrap items-center gap-2">
+              <dd class="mt-1 flex flex-wrap items-center">
                 {% set level = equipment.equipmentLevel.value %}
                 {% if level == 'national' %}
                   <span class="inline-flex items-center rounded-full bg-purple-100 px-2 py-0.5 text-xs font-semibold text-purple-800">National</span>
-                  <span class="text-sm font-semibold text-kyudo-gm-dark">- {{ equipment.ownerFederation ? equipment.ownerFederation.name : '-' }}</span>
+                  <span class="text-sm font-semibold text-kyudo-gm-dark">&nbsp;- {{ equipment.ownerFederation ? equipment.ownerFederation.name : '-' }}</span>
                 {% elseif level == 'regional' %}
                   <span class="inline-flex items-center rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-800">Régional</span>
-                  <span class="text-sm font-semibold text-kyudo-gm-dark">- {{ equipment.ownerRegion ? equipment.ownerRegion.name : '-' }}</span>
+                  <span class="text-sm font-semibold text-kyudo-gm-dark">&nbsp;- {{ equipment.ownerRegion ? equipment.ownerRegion.name : '-' }}</span>
                 {% else %}
                   <span class="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-800">Club</span>
-                  <span class="text-sm font-semibold text-kyudo-gm-dark">- {{ equipment.ownerClub ? equipment.ownerClub.name : '-' }}</span>
+                  <span class="text-sm font-semibold text-kyudo-gm-dark">&nbsp;- {{ equipment.ownerClub ? equipment.ownerClub.name : '-' }}</span>
                 {% endif %}
               </dd>
             </div>


### PR DESCRIPTION
## Description
Remplace les clés de traduction anglaises toutes en minuscule par les traductions:
<img width="232" height="324" alt="image" src="https://github.com/user-attachments/assets/75fb16cc-b1b5-4c6e-b95c-93dea255dc18" />
<img width="307" height="514" alt="image" src="https://github.com/user-attachments/assets/4a25e59a-915a-4810-9832-5d53ba63fcf5" />

Réduction de l'espace entre la pillule de propriétaire et son nom:
<img width="387" height="104" alt="image" src="https://github.com/user-attachments/assets/38105098-8c43-4a32-a538-bea861ae3dff" />
<img width="394" height="119" alt="image" src="https://github.com/user-attachments/assets/f580e04d-fcdd-4cca-a757-b4b5438e0479" />
