### PR TITLE
fix: redirige de login vers app_home si on est déjà connecté

### DIFF
--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -18,6 +18,10 @@ class SecurityController extends AbstractController
     #[Route(path: '/login', name: 'app_login')]
     public function login(): Response
     {
+        if ($this->getUser()) {
+            return $this->redirectToRoute('app_home');
+        }
+
         // get the login error if there is one
         $error = $this->authenticationUtils->getLastAuthenticationError();
         // last username entered by the user


### PR DESCRIPTION
## Description
Permet d'éviter de confuser l'utilisateur: si pour une raison ou une autre, il arrive sur la page de login (via une erreur de logique sur les boutons de retour ou bien en appuyant sur précédent dans son navigateur) alors qu'il est déjà connecté, on le redirige vers `app_home`