### PR TITLE
Gestion clubs: Fix cumul de role inter-clubs

### DIFF
--- a/src/Controller/UserClubAssignController.php
+++ b/src/Controller/UserClubAssignController.php
@@ -9,7 +9,6 @@ use App\Enum\UserRole;
 use App\Form\UserClubAssignType;
 use App\Security\Voter\UserPermissionVoter;
 use App\Service\UserClubAssigner;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,7 +19,6 @@ final class UserClubAssignController extends AbstractController
 {
     public function __construct(
         private readonly UserClubAssigner $userClubAssigner,
-        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -35,7 +33,6 @@ final class UserClubAssignController extends AbstractController
 
         if ($form->isSubmitted() && $form->isValid()) {
             $this->userClubAssigner->assign($targetUser, $form);
-            $this->entityManager->flush();
 
             $this->addFlash('success', 'Club mis à jour pour cet utilisateur.');
 

--- a/src/Controller/UserClubAssignController.php
+++ b/src/Controller/UserClubAssignController.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Entity\Club;
 use App\Entity\User;
 use App\Enum\UserRole;
 use App\Form\UserClubAssignType;
 use App\Security\Voter\UserPermissionVoter;
-use App\Service\ClubRoleManager;
+use App\Service\UserClubAssigner;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,85 +19,23 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final class UserClubAssignController extends AbstractController
 {
     public function __construct(
-        private readonly ClubRoleManager $clubRoleManager,
+        private readonly UserClubAssigner $userClubAssigner,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 
     #[Route('/user/{id}/club', name: 'user_assign_club', requirements: ['id' => '\\d+'], methods: ['GET', 'POST'])]
     #[IsGranted(UserPermissionVoter::ASSIGN_USER_TO_ANY_CLUB)]
-    public function assignClub(Request $request, User $targetUser, EntityManagerInterface $entityManager): Response
+    public function assignClub(Request $request, User $targetUser): Response
     {
-        /** @var User $currentUser */
-        $currentUser = $this->getUser();
-
-        $prevClubWhichImPresidentOf = $targetUser->getClubWhichImPresidentOf();
-        $prevClubWhereImEquipmentManager   = $targetUser->getClubWhereImEquipmentManager();
-
         $form = $this->createForm(UserClubAssignType::class, $targetUser, [
-            'current_user' => $currentUser,
+            'current_user' => $this->getUser(),
         ]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            // For inverse-side OneToOne fields, Symfony won't call the setter when null is submitted
-            // so we must explicitly clear them if the submitted value is null
-            $submittedPresidentClub    = $form->get('clubWhichImPresidentOf')->getData();
-            $submittedEquipmentManagerClub = $form->get('clubWhereImEquipmentManager')->getData();
-
-            if (null === $submittedPresidentClub && $prevClubWhichImPresidentOf instanceof Club) {
-                $targetUser->setClubWhichImPresidentOf(null);
-            }
-
-            if (null === $submittedEquipmentManagerClub && $prevClubWhereImEquipmentManager instanceof Club) {
-                $targetUser->setClubWhereImEquipmentManager(null);
-            }
-
-            $newClubWhichImPresidentOf = $targetUser->getClubWhichImPresidentOf();
-            $newClubWhereImEquipmentManagerOf   = $targetUser->getClubWhereImEquipmentManager();
-
-            if ($newClubWhichImPresidentOf instanceof Club) {
-                $previousPresidentOfClub = $entityManager
-                    ->createQuery('SELECT u FROM App\Entity\User u JOIN u.clubWhichImPresidentOf c WHERE c.id = :id')
-                    ->setParameter('id', $newClubWhichImPresidentOf->getId())
-                    ->getOneOrNullResult();
-            } else {
-                $previousPresidentOfClub = $prevClubWhichImPresidentOf instanceof Club ? $targetUser : null;
-            }
-
-            $newPresidentOfClub      = $newClubWhichImPresidentOf instanceof Club ? $targetUser : null;
-
-            if ($newClubWhereImEquipmentManagerOf instanceof Club) {
-                $previousManagerOfClub = $entityManager
-                    ->createQuery('SELECT u FROM App\Entity\User u JOIN u.clubWhereImEquipmentManager c WHERE c.id = :id')
-                    ->setParameter('id', $newClubWhereImEquipmentManagerOf->getId())
-                    ->getOneOrNullResult();
-            } else {
-                $previousManagerOfClub = $prevClubWhereImEquipmentManager instanceof Club ? $targetUser : null;
-            }
-
-            $newManagerOfClub      = $newClubWhereImEquipmentManagerOf instanceof Club ? $targetUser : null;
-
-            $this->clubRoleManager->syncClubRoles($previousPresidentOfClub, $newPresidentOfClub, $previousManagerOfClub, $newManagerOfClub);
-
-            // Force owning-side update regardless of what handleRequest() did to mark the fields as dirty so Doctrine flushes them
-            if ($newClubWhichImPresidentOf instanceof Club) {
-                $newClubWhichImPresidentOf->setPresident($targetUser);
-            }
-
-            if ($newClubWhereImEquipmentManagerOf instanceof Club) {
-                $newClubWhereImEquipmentManagerOf->setEquipmentManager($targetUser);
-            }
-
-            // Clear old clubs' owning side
-            if ($prevClubWhichImPresidentOf instanceof Club) {
-                $prevClubWhichImPresidentOf->setPresident(null);
-            }
-
-            if ($prevClubWhereImEquipmentManager instanceof Club) {
-                $prevClubWhereImEquipmentManager->setEquipmentManager(null);
-            }
-
-            $entityManager->flush();
+            $this->userClubAssigner->assign($targetUser, $form);
+            $this->entityManager->flush();
 
             $this->addFlash('success', 'Club mis à jour pour cet utilisateur.');
 

--- a/src/Form/ClubType.php
+++ b/src/Form/ClubType.php
@@ -7,6 +7,7 @@ namespace App\Form;
 use App\Entity\Club;
 use App\Entity\Region;
 use App\Entity\User;
+use App\Repository\ClubRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -21,6 +22,11 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 class ClubType extends AbstractType
 {
+    public function __construct(
+        private readonly ClubRepository $clubRepository,
+    ) {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
 
@@ -44,9 +50,9 @@ class ClubType extends AbstractType
             ->add('equipmentManager', EntityType::class, [
                 'class' => User::class,
                 'choice_value' => 'id',
-                'placeholder' => '--- choisir un gestionnaire matériel ---',
+                'placeholder' => '--- choisir un responsable matériel ---',
                 'required' => false,
-                'label' => 'Gestionnaire matériel',
+                'label' => 'Responsable matériel',
             ])
             ->add('email', EmailType::class, [
                 'label' => 'E-mail',
@@ -72,23 +78,53 @@ class ClubType extends AbstractType
     }
 
     /**
-     * Empêche qu'un même utilisateur soit à la fois président et gestionnaire
-     * matériel d'un club (rôles mutuellement exclusifs).
+     * Empêche :
+     * 1. Qu'un même utilisateur soit à la fois président et gestionnaire
+     *    matériel d'un club (rôles mutuellement exclusifs).
+     * 2. Qu'un utilisateur déjà président d'un club soit désigné gestionnaire
+     *    matériel d'un autre club, et vice versa.
      */
     public function validatePresidentAndEquipmentManager(Club $club, ExecutionContextInterface $context): void
     {
         $president        = $club->getPresident();
         $equipmentManager = $club->getEquipmentManager();
 
+        // Même utilisateur pour les deux rôles dans le même club
         if (
             $president instanceof User
             && $equipmentManager instanceof User
             && $president->getId() === $equipmentManager->getId()
         ) {
             $context
-                ->buildViolation('Un utilisateur ne peut pas être à la fois président et gestionnaire matériel d\'un club.')
+                ->buildViolation('Un utilisateur ne peut pas être à la fois président et responsable matériel d\'un club.')
                 ->atPath('equipmentManager')
                 ->addViolation();
+
+            return;
+        }
+
+        $clubId = $club->getId();
+
+        // Un président ne peut pas être responsable matériel d'un autre club
+        if ($president instanceof User) {
+            $otherClub = $this->clubRepository->findOneByEquipmentManagerExcluding($president, $clubId);
+            if ($otherClub instanceof Club) {
+                $context
+                    ->buildViolation('Cet utilisateur est déjà responsable matériel d\'un club.')
+                    ->atPath('president')
+                    ->addViolation();
+            }
+        }
+
+        // Un responsable matériel ne peut pas être président d'un autre club
+        if ($equipmentManager instanceof User) {
+            $otherClub = $this->clubRepository->findOneByPresidentExcluding($equipmentManager, $clubId);
+            if ($otherClub instanceof Club) {
+                $context
+                    ->buildViolation('Cet utilisateur est déjà président d\'un club.')
+                    ->atPath('equipmentManager')
+                    ->addViolation();
+            }
         }
     }
 }

--- a/src/Form/ClubType.php
+++ b/src/Form/ClubType.php
@@ -79,9 +79,9 @@ class ClubType extends AbstractType
 
     /**
      * Empêche :
-     * 1. Qu'un même utilisateur soit à la fois président et gestionnaire
+     * 1. Qu'un même utilisateur soit à la fois président et responsable
      *    matériel d'un club (rôles mutuellement exclusifs).
-     * 2. Qu'un utilisateur déjà président d'un club soit désigné gestionnaire
+     * 2. Qu'un utilisateur déjà président d'un club soit désigné responsable
      *    matériel d'un autre club, et vice versa.
      */
     public function validatePresidentAndEquipmentManager(Club $club, ExecutionContextInterface $context): void

--- a/src/Repository/ClubRepository.php
+++ b/src/Repository/ClubRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Club;
+use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
@@ -17,6 +18,34 @@ class ClubRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Club::class);
+    }
+
+    public function findOneByEquipmentManagerExcluding(User $user, ?int $excludeClubId = null): ?Club
+    {
+        $qb = $this->createQueryBuilder('c')
+            ->andWhere('c.equipmentManager = :user')
+            ->setParameter('user', $user);
+
+        if (null !== $excludeClubId) {
+            $qb->andWhere('c.id != :excludeId')
+                ->setParameter('excludeId', $excludeClubId);
+        }
+
+        return $qb->getQuery()->getOneOrNullResult();
+    }
+
+    public function findOneByPresidentExcluding(User $user, ?int $excludeClubId = null): ?Club
+    {
+        $qb = $this->createQueryBuilder('c')
+            ->andWhere('c.president = :user')
+            ->setParameter('user', $user);
+
+        if (null !== $excludeClubId) {
+            $qb->andWhere('c.id != :excludeId')
+                ->setParameter('excludeId', $excludeClubId);
+        }
+
+        return $qb->getQuery()->getOneOrNullResult();
     }
 
     public function findBySearchTerm(

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\Club;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -35,28 +36,23 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         $this->getEntityManager()->flush();
     }
 
-    //    /**
-    //     * @return User[] Returns an array of User objects
-    //     */
-    //    public function findByExampleField($value): array
-    //    {
-    //        return $this->createQueryBuilder('u')
-    //            ->andWhere('u.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->orderBy('u.id', 'ASC')
-    //            ->setMaxResults(10)
-    //            ->getQuery()
-    //            ->getResult()
-    //        ;
-    //    }
+    public function findPresidentOfClub(Club $club): ?User
+    {
+        return $this->createQueryBuilder('u')
+            ->join('u.clubWhichImPresidentOf', 'c')
+            ->where('c.id = :id')
+            ->setParameter('id', $club->getId())
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 
-    //    public function findOneBySomeField($value): ?User
-    //    {
-    //        return $this->createQueryBuilder('u')
-    //            ->andWhere('u.exampleField = :val')
-    //            ->setParameter('val', $value)
-    //            ->getQuery()
-    //            ->getOneOrNullResult()
-    //        ;
-    //    }
+    public function findEquipmentManagerOfClub(Club $club): ?User
+    {
+        return $this->createQueryBuilder('u')
+            ->join('u.clubWhereImEquipmentManager', 'c')
+            ->where('c.id = :id')
+            ->setParameter('id', $club->getId())
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
 }

--- a/src/Service/UserClubAssigner.php
+++ b/src/Service/UserClubAssigner.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use App\Entity\Club;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Form\FormInterface;
+
+final readonly class UserClubAssigner
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private ClubRoleManager $clubRoleManager,
+    ) {
+    }
+
+    /**
+     * @param FormInterface<User> $form
+     */
+    public function assign(User $targetUser, FormInterface $form): void
+    {
+        $originalData = $this->entityManager->getUnitOfWork()->getOriginalEntityData($targetUser);
+
+        $prevPresidentClub = $originalData['clubWhichImPresidentOf'] ?? null;
+        $prevManagerClub = $originalData['clubWhereImEquipmentManager'] ?? null;
+
+        $this->handleInverseSideNull($targetUser, $form, $prevPresidentClub, $prevManagerClub);
+
+        $newPresidentClub = $targetUser->getClubWhichImPresidentOf();
+        $newManagerClub = $targetUser->getClubWhereImEquipmentManager();
+
+        $previousPresident = $this->resolvePreviousPresident($newPresidentClub, $prevPresidentClub, $targetUser);
+        $previousManager = $this->resolvePreviousManager($newManagerClub, $prevManagerClub, $targetUser);
+
+        $this->clubRoleManager->syncClubRoles(
+            $previousPresident,
+            $newPresidentClub instanceof Club ? $targetUser : null,
+            $previousManager,
+            $newManagerClub instanceof Club ? $targetUser : null,
+        );
+
+        if ($newPresidentClub instanceof Club) {
+            $newPresidentClub->setPresident($targetUser);
+        }
+
+        if ($prevPresidentClub instanceof Club) {
+            $prevPresidentClub->setPresident(null);
+        }
+
+        if ($newManagerClub instanceof Club) {
+            $newManagerClub->setEquipmentManager($targetUser);
+        }
+
+        if ($prevManagerClub instanceof Club) {
+            $prevManagerClub->setEquipmentManager(null);
+        }
+    }
+
+    /**
+     * @param FormInterface<User> $form
+     */
+    private function handleInverseSideNull(User $targetUser, FormInterface $form, ?Club $prevPresidentClub, ?Club $prevManagerClub): void
+    {
+        $submittedPresidentClub = $form->get('clubWhichImPresidentOf')->getData();
+        $submittedManagerClub = $form->get('clubWhereImEquipmentManager')->getData();
+
+        if (null === $submittedPresidentClub && $prevPresidentClub instanceof Club) {
+            $targetUser->setClubWhichImPresidentOf(null);
+        }
+
+        if (null === $submittedManagerClub && $prevManagerClub instanceof Club) {
+            $targetUser->setClubWhereImEquipmentManager(null);
+        }
+    }
+
+    private function resolvePreviousPresident(?Club $newPresidentClub, ?Club $prevPresidentClub, User $targetUser): ?User
+    {
+        if ($newPresidentClub instanceof Club) {
+            return $this->findPresidentOfClub($newPresidentClub);
+        }
+
+        return $prevPresidentClub instanceof Club ? $targetUser : null;
+    }
+
+    private function resolvePreviousManager(?Club $newManagerClub, ?Club $prevManagerClub, User $targetUser): ?User
+    {
+        if ($newManagerClub instanceof Club) {
+            return $this->findEquipmentManagerOfClub($newManagerClub);
+        }
+
+        return $prevManagerClub instanceof Club ? $targetUser : null;
+    }
+
+    private function findPresidentOfClub(Club $club): ?User
+    {
+        return $this->entityManager
+            ->createQuery('SELECT u FROM App\Entity\User u JOIN u.clubWhichImPresidentOf c WHERE c.id = :id')
+            ->setParameter('id', $club->getId())
+            ->getOneOrNullResult();
+    }
+
+    private function findEquipmentManagerOfClub(Club $club): ?User
+    {
+        return $this->entityManager
+            ->createQuery('SELECT u FROM App\Entity\User u JOIN u.clubWhereImEquipmentManager c WHERE c.id = :id')
+            ->setParameter('id', $club->getId())
+            ->getOneOrNullResult();
+    }
+}

--- a/src/Service/UserClubAssigner.php
+++ b/src/Service/UserClubAssigner.php
@@ -6,6 +6,7 @@ namespace App\Service;
 
 use App\Entity\Club;
 use App\Entity\User;
+use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Form\FormInterface;
 
@@ -14,6 +15,7 @@ final readonly class UserClubAssigner
     public function __construct(
         private EntityManagerInterface $entityManager,
         private ClubRoleManager $clubRoleManager,
+        private UserRepository $userRepository,
     ) {
     }
 
@@ -57,6 +59,8 @@ final readonly class UserClubAssigner
         if ($prevManagerClub instanceof Club) {
             $prevManagerClub->setEquipmentManager(null);
         }
+
+        $this->entityManager->flush();
     }
 
     /**
@@ -79,7 +83,7 @@ final readonly class UserClubAssigner
     private function resolvePreviousPresident(?Club $newPresidentClub, ?Club $prevPresidentClub, User $targetUser): ?User
     {
         if ($newPresidentClub instanceof Club) {
-            return $this->findPresidentOfClub($newPresidentClub);
+            return $this->userRepository->findPresidentOfClub($newPresidentClub);
         }
 
         return $prevPresidentClub instanceof Club ? $targetUser : null;
@@ -88,25 +92,9 @@ final readonly class UserClubAssigner
     private function resolvePreviousManager(?Club $newManagerClub, ?Club $prevManagerClub, User $targetUser): ?User
     {
         if ($newManagerClub instanceof Club) {
-            return $this->findEquipmentManagerOfClub($newManagerClub);
+            return $this->userRepository->findEquipmentManagerOfClub($newManagerClub);
         }
 
         return $prevManagerClub instanceof Club ? $targetUser : null;
-    }
-
-    private function findPresidentOfClub(Club $club): ?User
-    {
-        return $this->entityManager
-            ->createQuery('SELECT u FROM App\Entity\User u JOIN u.clubWhichImPresidentOf c WHERE c.id = :id')
-            ->setParameter('id', $club->getId())
-            ->getOneOrNullResult();
-    }
-
-    private function findEquipmentManagerOfClub(Club $club): ?User
-    {
-        return $this->entityManager
-            ->createQuery('SELECT u FROM App\Entity\User u JOIN u.clubWhereImEquipmentManager c WHERE c.id = :id')
-            ->setParameter('id', $club->getId())
-            ->getOneOrNullResult();
     }
 }

--- a/tests/Functional/ClubControllerTest.php
+++ b/tests/Functional/ClubControllerTest.php
@@ -403,7 +403,7 @@ final class ClubControllerTest extends AbstractWebTestCase
         /** @var ClubRepository $clubRepo */
         $clubRepo = $container->get(ClubRepository::class);
 
-        $clubA    = $clubRepo->findOneBy(['name' => AppFixtures::CLUB_A]);
+        $clubA      = $clubRepo->findOneBy(['name' => AppFixtures::CLUB_A]);
         $userMember = $userRepo->findOneBy(['email' => AppFixtures::USER_MEMBER]);
         $this->assertInstanceOf(Club::class, $clubA);
         $this->assertInstanceOf(User::class, $userMember);

--- a/tests/Functional/ClubControllerTest.php
+++ b/tests/Functional/ClubControllerTest.php
@@ -478,7 +478,7 @@ final class ClubControllerTest extends AbstractWebTestCase
         /** @var ClubRepository $clubRepo */
         $clubRepo = $container->get(ClubRepository::class);
 
-        $clubB           = $clubRepo->findOneBy(['name' => AppFixtures::CLUB_B]);
+        $clubB            = $clubRepo->findOneBy(['name' => AppFixtures::CLUB_B]);
         $equipmentManager = $userRepo->findOneBy(['email' => AppFixtures::USER_MANAGER_CLUB]);
 
         $this->assertInstanceOf(Club::class, $clubB);

--- a/tests/Functional/ClubControllerTest.php
+++ b/tests/Functional/ClubControllerTest.php
@@ -11,6 +11,7 @@ use App\Enum\UserRole;
 use App\Repository\ClubRepository;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Tests fonctionnels : ClubController.
@@ -421,7 +422,83 @@ final class ClubControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(422);
         $this->assertSelectorTextContains(
             'body',
-            'Un utilisateur ne peut pas être à la fois président et gestionnaire matériel'
+            'Un utilisateur ne peut pas être à la fois président et responsable matériel'
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Validation : cumul inter-club interdit
+    // -----------------------------------------------------------------------
+
+    /**
+     * Le formulaire doit rejeter le cas où on tente de désigner comme
+     * gestionnaire matériel d'un club un utilisateur déjà président d'un autre club.
+     */
+    public function testCannotSetPresidentAsEquipmentManagerOfOtherClub(): void
+    {
+        $container = self::getContainer();
+        /** @var UserRepository $userRepo */
+        $userRepo = $container->get(UserRepository::class);
+        /** @var ClubRepository $clubRepo */
+        $clubRepo = $container->get(ClubRepository::class);
+
+        $clubB     = $clubRepo->findOneBy(['name' => AppFixtures::CLUB_B]);
+        $president = $userRepo->findOneBy(['email' => AppFixtures::USER_PRESIDENT]);
+
+        $this->assertInstanceOf(Club::class, $clubB);
+        $this->assertInstanceOf(User::class, $president);
+
+        // Club B (Lyon) a déjà un gestionnaire matériel (managerLyon).
+        // On essaie d'y mettre le président du Club A.
+        $this->loginAs(AppFixtures::USER_ADMIN);
+
+        $crawler = $this->client->request('GET', '/club/'.$clubB->getId().'/edit');
+        $form    = $crawler->selectButton('Enregistrer')->form();
+
+        $form['club[equipmentManager]'] = (string) $president->getId();
+        $this->client->submit($form);
+
+        // Doit échouer en validation
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertSelectorTextContains(
+            'body',
+            'Cet utilisateur est déjà président d\'un club.'
+        );
+    }
+
+    /**
+     * Le formulaire doit rejeter le cas où on tente de désigner comme
+     * président d'un club un utilisateur déjà gestionnaire matériel d'un autre club.
+     */
+    public function testCannotSetEquipmentManagerAsPresidentOfOtherClub(): void
+    {
+        $container = self::getContainer();
+        /** @var UserRepository $userRepo */
+        $userRepo = $container->get(UserRepository::class);
+        /** @var ClubRepository $clubRepo */
+        $clubRepo = $container->get(ClubRepository::class);
+
+        $clubB           = $clubRepo->findOneBy(['name' => AppFixtures::CLUB_B]);
+        $equipmentManager = $userRepo->findOneBy(['email' => AppFixtures::USER_MANAGER_CLUB]);
+
+        $this->assertInstanceOf(Club::class, $clubB);
+        $this->assertInstanceOf(User::class, $equipmentManager);
+
+        // Club B (Lyon) a déjà un président (presidentLyon).
+        // On essaie d'y mettre le gestionnaire matériel du Club A.
+        $this->loginAs(AppFixtures::USER_ADMIN);
+
+        $crawler = $this->client->request('GET', '/club/'.$clubB->getId().'/edit');
+        $form    = $crawler->selectButton('Enregistrer')->form();
+
+        $form['club[president]'] = (string) $equipmentManager->getId();
+        $this->client->submit($form);
+
+        // Doit échouer en validation
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->assertSelectorTextContains(
+            'body',
+            'Cet utilisateur est déjà responsable matériel d\'un club.'
         );
     }
 }

--- a/tests/Functional/ClubControllerTest.php
+++ b/tests/Functional/ClubControllerTest.php
@@ -432,7 +432,7 @@ final class ClubControllerTest extends AbstractWebTestCase
 
     /**
      * Le formulaire doit rejeter le cas où on tente de désigner comme
-     * gestionnaire matériel d'un club un utilisateur déjà président d'un autre club.
+     * responsable matériel d'un club un utilisateur déjà président d'un autre club.
      */
     public function testCannotSetPresidentAsEquipmentManagerOfOtherClub(): void
     {
@@ -448,7 +448,7 @@ final class ClubControllerTest extends AbstractWebTestCase
         $this->assertInstanceOf(Club::class, $clubB);
         $this->assertInstanceOf(User::class, $president);
 
-        // Club B (Lyon) a déjà un gestionnaire matériel (managerLyon).
+        // Club B (Lyon) a déjà un responsable matériel (managerLyon).
         // On essaie d'y mettre le président du Club A.
         $this->loginAs(AppFixtures::USER_ADMIN);
 
@@ -468,7 +468,7 @@ final class ClubControllerTest extends AbstractWebTestCase
 
     /**
      * Le formulaire doit rejeter le cas où on tente de désigner comme
-     * président d'un club un utilisateur déjà gestionnaire matériel d'un autre club.
+     * président d'un club un utilisateur déjà responsable matériel d'un autre club.
      */
     public function testCannotSetEquipmentManagerAsPresidentOfOtherClub(): void
     {
@@ -485,7 +485,7 @@ final class ClubControllerTest extends AbstractWebTestCase
         $this->assertInstanceOf(User::class, $equipmentManager);
 
         // Club B (Lyon) a déjà un président (presidentLyon).
-        // On essaie d'y mettre le gestionnaire matériel du Club A.
+        // On essaie d'y mettre le responsable matériel du Club A.
         $this->loginAs(AppFixtures::USER_ADMIN);
 
         $crawler = $this->client->request('GET', '/club/'.$clubB->getId().'/edit');


### PR DESCRIPTION
## Description
- Résout #74 
- Refacto de l'assignation de clubs dans la gestion utilisateur pour passer par un service et réduire la logique dans le controller