### PR TITLE
fix: modification securité pour permettre le caching des svg des qr codes

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -23,6 +23,9 @@ security:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
+        qr_code_svg:
+            pattern: ^/qr-code/[0-9a-f\-]{36}/svg$
+            security: false
         main:
             lazy: true
             provider: app_user_provider

--- a/src/Controller/QRCodeController.php
+++ b/src/Controller/QRCodeController.php
@@ -212,7 +212,6 @@ final class QRCodeController extends AbstractController
      * Sert le SVG du QR code comme image (utilisé dans les balises <img>).
      */
     #[Route('/{uuid}/svg', name: 'qr_code.svg', requirements: ['uuid' => '[0-9a-f\-]{36}'], methods: ['GET'])]
-    #[IsGranted(UserPermissionVoter::VIEW_QRCODE)]
     public function svg(string $uuid, QRCodeRepository $repository): Response
     {
         $qrCode = $repository->findByUuid($uuid);
@@ -225,7 +224,7 @@ final class QRCodeController extends AbstractController
 
         return new Response($svg, 200, [
             'Content-Type' => 'image/svg+xml',
-            'Cache-Control' => 'public, max-age=3600',
+            'Cache-Control' => 'public, max-age=31536000',
         ]);
     }
 

--- a/tests/Functional/EquipmentSearchFilterTest.php
+++ b/tests/Functional/EquipmentSearchFilterTest.php
@@ -468,6 +468,7 @@ final class EquipmentSearchFilterTest extends AbstractWebTestCase
         /** @var \App\Repository\UserRepository $repo */
         $repo = self::getContainer()->get(\App\Repository\UserRepository::class);
         $memberUser = $repo->findOneBy(['email' => AppFixtures::USER_MEMBER]);
+        $this->assertInstanceOf(\App\Entity\User::class, $memberUser);
         $crawler = $this->requestIndex(['borrowed' => (string) $memberUser->getId()]);
         $this->assertResponseIsSuccessful();
         $this->assertSame(2, $this->countEquipmentRows($crawler));
@@ -482,6 +483,7 @@ final class EquipmentSearchFilterTest extends AbstractWebTestCase
         /** @var \App\Repository\UserRepository $repo */
         $repo = self::getContainer()->get(\App\Repository\UserRepository::class);
         $memberUser = $repo->findOneBy(['email' => AppFixtures::USER_MEMBER]);
+        $this->assertInstanceOf(\App\Entity\User::class, $memberUser);
         $crawler = $this->requestIndex(['borrowed' => (string) $memberUser->getId(), 'equipmentType' => 'yumi']);
         $this->assertResponseIsSuccessful();
         $this->assertSame(1, $this->countEquipmentRows($crawler));
@@ -495,6 +497,7 @@ final class EquipmentSearchFilterTest extends AbstractWebTestCase
         /** @var \App\Repository\UserRepository $repo */
         $repo = self::getContainer()->get(\App\Repository\UserRepository::class);
         $adminUser = $repo->findOneBy(['email' => AppFixtures::USER_ADMIN]);
+        $this->assertInstanceOf(\App\Entity\User::class, $adminUser);
         $crawler = $this->requestIndex(['borrowed' => (string) $adminUser->getId()]);
         $this->assertResponseIsSuccessful();
         $this->assertSame(0, $this->countEquipmentRows($crawler));

--- a/tests/Functional/QRCodeControllerTest.php
+++ b/tests/Functional/QRCodeControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\DataFixtures\AppFixtures;
+use App\Entity\Equipment;
+use App\Entity\Glove;
+use App\Entity\QRCode;
+use App\Repository\EquipmentRepository;
+use App\Service\QRCodeService;
+
+/**
+ * Tests fonctionnels : QRCodeController.
+ *
+ * Routes testées :
+ *   GET /qr-code/{uuid}/svg → qr_code.svg
+ *
+ * Le SVG du QR code doit être mis en cache par le navigateur :
+ *   - Cache-Control: public, max-age=31536000
+ *   - Pas de session / Set-Cookie
+ */
+final class QRCodeControllerTest extends AbstractWebTestCase
+{
+    private string $qrCodeUuid;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $container = self::getContainer();
+
+        /** @var EquipmentRepository $repo */
+        $repo = $container->get(EquipmentRepository::class);
+
+        /** @var Equipment[] $gloves */
+        $gloves = $repo->findAll();
+
+        $equipment = null;
+        foreach ($gloves as $glove) {
+            // Prendre un gant Club A sans QR code existant
+            if ($glove instanceof Glove && AppFixtures::CLUB_A === $glove->getOwnerClub()?->getName() && !$glove->getQrCode() instanceof QRCode) {
+                $equipment = $glove;
+                break;
+            }
+        }
+
+        if (!$equipment instanceof Glove) {
+            throw new \RuntimeException('Aucun équipement disponible sans QR code dans les fixtures. Nécessite de recréer les fixtures.');
+        }
+
+        /** @var QRCodeService $qrCodeService */
+        $qrCodeService = $container->get(QRCodeService::class);
+        $qrCode = $qrCodeService->createForEquipment($equipment);
+
+        $this->qrCodeUuid = $qrCode->getUuid();
+    }
+
+    public function testSvgReturnsPublicCacheHeaders(): void
+    {
+        $this->client->request('GET', '/qr-code/'.$this->qrCodeUuid.'/svg');
+
+        $response = $this->client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('image/svg+xml', $response->headers->get('Content-Type'));
+
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertNotNull($cacheControl, 'Cache-Control header should be present');
+        $this->assertStringContainsString('public', $cacheControl, 'Cache-Control should allow public caching');
+        $this->assertStringContainsString('max-age=31536000', $cacheControl, 'Cache-Control should set max-age=31536000');
+    }
+
+    public function testSvgDoesNotStartSession(): void
+    {
+        $this->client->request('GET', '/qr-code/'.$this->qrCodeUuid.'/svg');
+
+        $response = $this->client->getResponse();
+
+        // Aucun Set-Cookie ne doit être émis (pas de session démarrée)
+        $this->assertNull(
+            $response->headers->get('Set-Cookie'),
+            'The SVG response must not set a session cookie, otherwise the browser will not cache it'
+        );
+    }
+
+    public function testSvgAccessibleWithoutAuthentication(): void
+    {
+        // Ne PAS appeler loginAs() → accès anonyme
+        $this->client->request('GET', '/qr-code/'.$this->qrCodeUuid.'/svg');
+
+        $response = $this->client->getResponse();
+
+        $this->assertSame(200, $response->getStatusCode(), 'The SVG route should be accessible without authentication');
+    }
+}


### PR DESCRIPTION
## Description
Résout #86.

L'URL `qr_code.svg` (`/qr-code/{uuid}/svg`) était derrière le pare-feu `main` qui utilise les sessions. Bien que le contrôleur définisse `Cache-Control: public, max-age=3600`, le `SessionListener` de Symfony le remplaçait par `private` car une session était active pour les utilisateurs authentifiés. Cela empêchait la mise en cache par le navigateur et le SVG était retéléchargé à chaque chargement de la page d'équipement.

## Correctif
**3 fichiers modifiés :**
1. **`config/packages/security.yaml`**: Ajout d'un pare-feu anonyme `qr_code_svg` ciblant `^/qr-code/[0-9a-f\-]{36}/svg$` avec `security: false` (placé avant `main`). Cela empêche Symfony de démarrer une session pour cette route, donc aucun en-tête `Set-Cookie` n'est émis.
2. **`src/Controller/QRCodeController.php:214-215`**: Suppression de `#[IsGranted(UserPermissionVoter::VIEW_QRCODE)]` de la méthode `svg()`. Le SVG du QR code peut être servi sans authentification : l'UUID est déjà exposé physiquement sur l'équipement, et l'URL encodée redirige simplement vers une page protégée par les droits.
3. **`tests/Functional/QRCodeControllerTest.php`**: 3 tests fonctionnels vérifiant :
   - La présence de `Cache-Control: public, max-age=31536000`
   - L'absence d'en-tête `Set-Cookie` (pas de session démarrée)
   - L'accessibilité de la route sans authentification