### PR TITLE
add data in fixture and admin can create a user

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -33,6 +33,7 @@ security:
                 login_path: app_login
                 check_path: app_login
                 enable_csrf: true
+                success_handler: App\Security\LoginAuthenticationSuccessHandler
             logout:
                 path: app_logout
                 # where to redirect after logout

--- a/migrations/Version20260702164147.php
+++ b/migrations/Version20260702164147.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260702164147 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add must_change_password on user';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE users ADD must_change_password BOOLEAN DEFAULT false NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE users DROP must_change_password');
+    }
+}

--- a/src/Controller/AdminUserController.php
+++ b/src/Controller/AdminUserController.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\User;
+use App\Form\AdminUserCreateType;
+use App\Service\PasswordGenerator;
+use App\Security\Voter\UserPermissionVoter;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+final class AdminUserController extends AbstractController
+{
+    public function __construct(
+        private readonly UserPasswordHasherInterface $userPasswordHasher,
+        private readonly PasswordGenerator $passwordGenerator,
+    ) {
+    }
+
+    /**
+     * Création d'un utilisateur par un administrateur.
+     *
+     * Un mot de passe aléatoire est généré (12 caractères, 1 majuscule, 1 caractère spécial).
+     * L'utilisateur est créé avec ROLE_USER et mustChangePassword = true afin d'être
+     * contraint de définir son propre mot de passe à la première connexion.
+     */
+    #[Route('/admin/users/create', name: 'admin_user_create', methods: ['GET', 'POST'])]
+    #[IsGranted(UserPermissionVoter::CREATE_USER)]
+    public function createUser(Request $request, EntityManagerInterface $entityManager): Response
+    {
+        $user = new User();
+        $form = $this->createForm(AdminUserCreateType::class, $user);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $plainPassword = $this->passwordGenerator->generate();
+            $user->setPassword($this->userPasswordHasher->hashPassword($user, $plainPassword));
+            $user->setMustChangePassword(true);
+            $user->setRoles([]);
+
+            $entityManager->persist($user);
+            $entityManager->flush();
+
+            $request->getSession()->set('admin_user_created', [
+                'email' => $user->getEmail(),
+                'plainPassword' => $plainPassword,
+            ]);
+
+            return $this->redirectToRoute('admin_user_create_success');
+        }
+
+        return $this->render('admin/user/create.html.twig', [
+            'form' => $form,
+        ]);
+    }
+
+    /**
+     * Page de confirmation affichant les identifiants du nouvel utilisateur.
+     *
+     * Affiche l'email et le mot de passe généré qui doivent être communiqués à l'utilisateur.
+     */
+    #[Route('/admin/users/create/success', name: 'admin_user_create_success', methods: ['GET'])]
+    #[IsGranted(UserPermissionVoter::CREATE_USER)]
+    public function createSuccess(Request $request): Response
+    {
+        $sessionData = $request->getSession()->get('admin_user_created');
+
+        if (!$sessionData) {
+            return $this->redirectToRoute('admin_user_create');
+        }
+
+        $request->getSession()->remove('admin_user_created');
+
+        return $this->render('admin/user/create-success.html.twig', [
+            'email' => $sessionData['email'],
+            'plainPassword' => $sessionData['plainPassword'],
+        ]);
+    }
+}

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -7,6 +7,7 @@ namespace App\Controller;
 use App\Entity\User;
 use App\Enum\UserRole;
 use App\Form\ChangePasswordFormType;
+use App\Form\ForceChangePasswordType;
 use App\Form\UserProfileType;
 use App\Repository\UserRepository;
 use App\Security\Voter\UserPermissionVoter;
@@ -83,6 +84,37 @@ final class UserController extends AbstractController
         }
 
         return $this->render('user/change_password.html.twig', [
+            'form' => $form,
+        ]);
+    }
+
+    #[Route('/profile/password/force', name: 'user_force_change_password', methods: ['GET', 'POST'])]
+    #[IsGranted(UserPermissionVoter::EDIT_OWN_ACCOUNT_INFORMATION)]
+    public function forceChangePassword(Request $request, EntityManagerInterface $entityManager): Response
+    {
+        $user = $this->getAuthenticatedUser();
+
+        if (!$user->isMustChangePassword()) {
+            return $this->redirectToRoute('user_profile');
+        }
+
+        $form = $this->createForm(ForceChangePasswordType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            /** @var string $plainPassword */
+            $plainPassword = $form->get('plainPassword')->getData();
+
+            $user->setPassword($this->userPasswordHasher->hashPassword($user, $plainPassword));
+            $user->setMustChangePassword(false);
+            $entityManager->flush();
+
+            $this->addFlash('success', 'Votre mot de passe a bien été modifié. Bienvenue !');
+
+            return $this->redirectToRoute('user_profile');
+        }
+
+        return $this->render('user/force_change_password.html.twig', [
             'form' => $form,
         ]);
     }

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -30,7 +30,7 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  *   member@kyudo-test.fr    → ROLE_MEMBER (membre du Club A)
  *   president@kyudo-test.fr → ROLE_CLUB_PRESIDENT (président du Club A)
  *   mgr-club@kyudo-test.fr  → ROLE_EQUIPMENT_MANAGER_CLUB (gestionnaire matériel du Club A)
- *   mgr-ctk@kyudo-test.fr   → ROLE_EQUIPMENT_MANAGER_CTK (gestionnaire de Région A – Île-de-France)
+ *   mgr-ctk@kyudo-test.fr   → ROLE_EQUIPMENT_MANAGER_CTK (gestionnaire de Région A – Ile de France)
  *   mgr-cn@kyudo-test.fr    → ROLE_EQUIPMENT_MANAGER_CN
  *   admin@kyudo-test.fr     → ROLE_ADMIN
  *
@@ -41,34 +41,43 @@ use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
  *   - Comité National de Kyudo (CNKyudo)
  *
  * Régions (CTK) :
- *   - Île-de-France          (Région A — gérée par mgr-ctk@kyudo-test.fr)
- *   - Auvergne-Rhône-Alpes   (Région B)
- *   - Bretagne                (Région C)
+ *   - Ile de France        (Région A — gérée par mgr-ctk@kyudo-test.fr)
+ *   - Auvergne Rhone Alpe  (Région B)
+ *   - Arc Atlantique       (Région C)
+ *   - Nord & Est           (Région D)
+ *   - Grand Sud            (Région E)
  *
- * Clubs (10) :
- *   Île-de-France :
+ * Clubs (15) :
+ *   Ile de France :
  *     - Kyudo Paris Marais      (Club A — présidé par president@kyudo-test.fr, géré par mgr-club@kyudo-test.fr)
  *     - Kyudo Vincennes          (Club C — même région que Club A, pour tester les restrictions régionales)
  *     - Ryushin Dojo Paris       (Club D)
- *   Auvergne-Rhône-Alpes :
+ *   Auvergne Rhone Alpe :
  *     - Kyudo Lyon               (Club B — sans président)
  *     - Kyudo Grenoble           (Club E)
  *     - Dojo Zen Clermont        (Club F)
- *   Bretagne :
+ *   Arc Atlantique :
  *     - Kyudo Rennes             (Club G)
- *     - Kyudo Brest              (Club H)
- *     - Dojo Bretagne Quimper    (Club I)
  *     - Kyudo Lorient            (Club J)
+ *     - Kyudo Nantes             (Club K)
+ *   Nord & Est :
+ *     - Kyudo Brest              (Club H)
+ *     - Kyudo Strasbourg         (Club L)
+ *     - Kyudo Lille              (Club M)
+ *   Grand Sud :
+ *     - Dojo Bretagne Quimper    (Club I)
+ *     - Kyudo Marseille          (Club N)
+ *     - Kyudo Toulouse           (Club O)
  *
- * Équipements (17) :
+ * Équipements (19) :
  *   Gants (Gake) :
  *     - 3 × niveau CLUB (clubs A, B, C)
  *     - 1 × niveau CLUB avec emprunteur club (Club G → Rennes)
  *     - 1 × niveau REGIONAL (Région A) disponible
- *     - 1 × niveau REGIONAL (Région A) emprunté  ← NOUVEAU
+ *     - 1 × niveau REGIONAL (Région A) emprunté
  *     - 1 × niveau REGIONAL (Région C) disponible
  *     - 1 × niveau NATIONAL disponible
- *     - 1 × niveau NATIONAL emprunté              ← NOUVEAU
+ *     - 1 × niveau NATIONAL emprunté
  *   Arcs (Yumi) :
  *     - 4 × niveau CLUB (clubs A, D, E, G)
  *     - 2 × niveau REGIONAL (régions B, C)
@@ -102,9 +111,15 @@ class AppFixtures extends Fixture
 
     public const CLUB_G = 'Kyudo Rennes';
 
-    public const REGION_A = 'Île-de-France';
+    public const REGION_A = 'Ile de France';
 
-    public const REGION_B = 'Auvergne-Rhône-Alpes';
+    public const REGION_B = 'Auvergne Rhone Alpe';
+
+    public const REGION_C = 'Arc Atlantique';
+
+    public const REGION_D = 'Nord & Est';
+
+    public const REGION_E = 'Grand Sud';
 
     public const FEDERATION_NAME = 'Comité National de Kyudo';
 
@@ -121,9 +136,6 @@ class AppFixtures extends Fixture
     public function load(ObjectManager $manager): void
     {
         $hashedPassword = $this->userPasswordHasher->hashPassword(new User(), self::PASSWORD);
-
-        // ────────────────────────────────────────────────────────────────────
-        // Fédération
 
         // ────────────────────────────────────────────────────────────────────
         // Fédération
@@ -150,9 +162,21 @@ class AppFixtures extends Fixture
 
         $regionC = new Region()
             ->setFederation($federation)
-            ->setName('Bretagne')
-            ->setEmail('ctk.bretagne@cnkyudo.fr');
+            ->setName(self::REGION_C)
+            ->setEmail('ctk.arc-atlantique@cnkyudo.fr');
         $manager->persist($regionC);
+
+        $regionD = new Region()
+            ->setFederation($federation)
+            ->setName(self::REGION_D)
+            ->setEmail('ctk.nord-est@cnkyudo.fr');
+        $manager->persist($regionD);
+
+        $regionE = new Region()
+            ->setFederation($federation)
+            ->setName(self::REGION_E)
+            ->setEmail('ctk.grand-sud@cnkyudo.fr');
+        $manager->persist($regionE);
 
         // ────────────────────────────────────────────────────────────────────
         // Comptes de test (requis par les tests fonctionnels)
@@ -179,14 +203,14 @@ class AppFixtures extends Fixture
             $u[$email] = $user;
         }
 
-        // manager_ctk gère la Région A (Île-de-France)
+        // manager_ctk gère la Région A (Ile de France)
         $u[self::USER_MANAGER_CTK]->addManagedRegion($regionA);
 
         // ────────────────────────────────────────────────────────────────────
         // Utilisateurs réalistes
         // ────────────────────────────────────────────────────────────────────
 
-        // Gestionnaire CTK Auvergne-Rhône-Alpes
+        // Gestionnaire CTK Auvergne Rhone Alpe
         $ctkAura = new User()
             ->setEmail('ctk.aura@cnkyudo.fr')
             ->setPassword($hashedPassword)
@@ -195,14 +219,32 @@ class AppFixtures extends Fixture
 
         $manager->persist($ctkAura);
 
-        // Gestionnaire CTK Bretagne
-        $ctkBretagne = new User()
-            ->setEmail('ctk.bretagne@cnkyudo.fr')
+        // Gestionnaire CTK Arc Atlantique
+        $ctkArcAtlantique = new User()
+            ->setEmail('ctk.arc-atlantique@cnkyudo.fr')
             ->setPassword($hashedPassword)
             ->setRoles([UserRole::EQUIPMENT_MANAGER_CTK->value]);
-        $ctkBretagne->addManagedRegion($regionC);
+        $ctkArcAtlantique->addManagedRegion($regionC);
 
-        $manager->persist($ctkBretagne);
+        $manager->persist($ctkArcAtlantique);
+
+        // Gestionnaire CTK Nord & Est
+        $ctkNordEst = new User()
+            ->setEmail('ctk.nord-est@cnkyudo.fr')
+            ->setPassword($hashedPassword)
+            ->setRoles([UserRole::EQUIPMENT_MANAGER_CTK->value]);
+        $ctkNordEst->addManagedRegion($regionD);
+
+        $manager->persist($ctkNordEst);
+
+        // Gestionnaire CTK Grand Sud
+        $ctkGrandSud = new User()
+            ->setEmail('ctk.grand-sud@cnkyudo.fr')
+            ->setPassword($hashedPassword)
+            ->setRoles([UserRole::EQUIPMENT_MANAGER_CTK->value]);
+        $ctkGrandSud->addManagedRegion($regionE);
+
+        $manager->persist($ctkGrandSud);
 
         // Membres et présidents supplémentaires
         $presidentLyon = new User()
@@ -247,11 +289,19 @@ class AppFixtures extends Fixture
             ->setRoles([UserRole::MEMBER->value]);
         $manager->persist($membre4);
 
+        for ($i = 0; $i < 25; ++$i) {
+            $membre = new User()
+            ->setEmail('user'.$i.'@kyudo.fr')
+            ->setPassword($hashedPassword)
+            ->setRoles([UserRole::MEMBER->value]);
+            $manager->persist($membre);
+        }
+
         // ────────────────────────────────────────────────────────────────────
         // Clubs
         // ────────────────────────────────────────────────────────────────────
 
-        // — Île-de-France —
+        // — Ile de France —
         $clubA = new Club()                                       // Club A (tests)
             ->setName(self::CLUB_A)
             ->setEmail('contact@kyudo-paris-marais.fr')
@@ -272,12 +322,12 @@ class AppFixtures extends Fixture
         $manager->persist($clubC);
 
         $clubD = new Club()
-            ->setName('Ryushin Dojo Paris')
+            ->setName(self::CLUB_D)
             ->setEmail('contact@ryushin-paris.fr')
             ->setRegion($regionA);
         $manager->persist($clubD);
 
-        // — Auvergne-Rhône-Alpes —
+        // — Auvergne Rhone Alpe —
         $clubB = new Club()                                       // Club B (tests)
             ->setName(self::CLUB_B)
             ->setEmail('contact@kyudo-lyon.fr')
@@ -300,9 +350,9 @@ class AppFixtures extends Fixture
             ->setRegion($regionB);
         $manager->persist($clubF);
 
-        // — Bretagne —
-        $clubG = new Club()
-            ->setName('Kyudo Rennes')
+        // — Arc Atlantique —
+        $clubG = new Club()                                       // Club G (tests)
+            ->setName(self::CLUB_G)
             ->setEmail('contact@kyudo-rennes.fr')
             ->setPresident($presidentRennes)
             ->setRegion($regionC);
@@ -310,23 +360,55 @@ class AppFixtures extends Fixture
 
         $manager->persist($clubG);
 
-        $clubH = new Club()
-            ->setName('Kyudo Brest')
-            ->setEmail('contact@kyudo-brest.fr')
-            ->setRegion($regionC);
-        $manager->persist($clubH);
-
-        $clubI = new Club()
-            ->setName('Dojo Bretagne Quimper')
-            ->setEmail('contact@dojo-quimper.fr')
-            ->setRegion($regionC);
-        $manager->persist($clubI);
-
         $clubJ = new Club()
             ->setName('Kyudo Lorient')
             ->setEmail('contact@kyudo-lorient.fr')
             ->setRegion($regionC);
         $manager->persist($clubJ);
+
+        $clubK = new Club()
+            ->setName('Kyudo Nantes')
+            ->setEmail('contact@kyudo-nantes.fr')
+            ->setRegion($regionC);
+        $manager->persist($clubK);
+
+        // — Nord & Est —
+        $clubH = new Club()
+            ->setName('Kyudo Brest')
+            ->setEmail('contact@kyudo-brest.fr')
+            ->setRegion($regionD);
+        $manager->persist($clubH);
+
+        $clubL = new Club()
+            ->setName('Kyudo Strasbourg')
+            ->setEmail('contact@kyudo-strasbourg.fr')
+            ->setRegion($regionD);
+        $manager->persist($clubL);
+
+        $clubM = new Club()
+            ->setName('Kyudo Lille')
+            ->setEmail('contact@kyudo-lille.fr')
+            ->setRegion($regionD);
+        $manager->persist($clubM);
+
+        // — Grand Sud —
+        $clubI = new Club()
+            ->setName('Dojo Bretagne Quimper')
+            ->setEmail('contact@dojo-quimper.fr')
+            ->setRegion($regionE);
+        $manager->persist($clubI);
+
+        $clubN = new Club()
+            ->setName('Kyudo Marseille')
+            ->setEmail('contact@kyudo-marseille.fr')
+            ->setRegion($regionE);
+        $manager->persist($clubN);
+
+        $clubO = new Club()
+            ->setName('Kyudo Toulouse')
+            ->setEmail('contact@kyudo-toulouse.fr')
+            ->setRegion($regionE);
+        $manager->persist($clubO);
 
         // ────────────────────────────────────────────────────────────────────
         // ClubMembers
@@ -402,7 +484,7 @@ class AppFixtures extends Fixture
             ->setSize(7);
         $manager->persist($gakeG);
 
-        // REGIONAL — Région A (Île-de-France)
+        // REGIONAL — Région A (Ile de France)
         $gakeRegA = new Gake()
             ->setOwnerRegion($regionA)
             ->setEquipmentLevel(EquipmentLevel::REGIONAL)
@@ -410,7 +492,7 @@ class AppFixtures extends Fixture
             ->setSize(8);
         $manager->persist($gakeRegA);
 
-        // REGIONAL — Région C (Bretagne)
+        // REGIONAL — Région C (Arc Atlantique)
         $gakeRegC = new Gake()
             ->setOwnerRegion($regionC)
             ->setEquipmentLevel(EquipmentLevel::REGIONAL)
@@ -435,7 +517,7 @@ class AppFixtures extends Fixture
             ->setBorrowerMember($memberLinked);
         $manager->persist($gakeNatBorrowed);
 
-        // REGIONAL — Région A (Île-de-France) — emprunté
+        // REGIONAL — Région A (Ile de France) — emprunté
         // (pour tester la restriction "dispo seulement" de MEMBER / PRESIDENT / MANAGER_CLUB)
         $gakeRegABorrowed = new Gake()
             ->setOwnerRegion($regionA)
@@ -489,7 +571,7 @@ class AppFixtures extends Fixture
             ->setYumiLength(YumiLength::NISUN_NOBI);
         $manager->persist($yumiG);
 
-        // REGIONAL — Région B (Auvergne-Rhône-Alpes)
+        // REGIONAL — Région B (Auvergne Rhone Alpe)
         $yumiRegB1 = new Yumi()
             ->setOwnerRegion($regionB)
             ->setEquipmentLevel(EquipmentLevel::REGIONAL)

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -41,6 +41,13 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
     #[ORM\Column]
     private string $password;
 
+    /**
+     * Indique si l'utilisateur doit changer son mot de passe à la prochaine connexion.
+     * Positionné à true lors de la création d'un compte par un administrateur.
+     */
+    #[ORM\Column(options: ['default' => false])]
+    private bool $mustChangePassword = false;
+
     #[ORM\OneToOne(mappedBy: 'president')]
     private ?Club $clubWhichImPresidentOf = null;
 
@@ -146,6 +153,18 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, \String
     public function setPassword(string $password): static
     {
         $this->password = $password;
+
+        return $this;
+    }
+
+    public function isMustChangePassword(): bool
+    {
+        return $this->mustChangePassword;
+    }
+
+    public function setMustChangePassword(bool $mustChangePassword): static
+    {
+        $this->mustChangePassword = $mustChangePassword;
 
         return $this;
     }

--- a/src/EventListener/PasswordChangeRequiredListener.php
+++ b/src/EventListener/PasswordChangeRequiredListener.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Entity\User;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+/**
+ * Redirige tout utilisateur ayant mustChangePassword = true vers la page de changement forcé.
+ *
+ * Les routes suivantes sont exemptées pour éviter les boucles de redirection :
+ *   - user_force_change_password (page cible)
+ *   - app_login
+ *   - app_logout
+ */
+#[AsEventListener(event: KernelEvents::REQUEST, priority: 10)]
+final readonly class PasswordChangeRequiredListener
+{
+    /** @var list<string> Routes exemptées de la redirection */
+    private const array EXCLUDED_ROUTES = [
+        'user_force_change_password',
+        'app_login',
+        'app_logout',
+    ];
+
+    public function __construct(
+        private TokenStorageInterface $tokenStorage,
+        private RouterInterface $router,
+    ) {
+    }
+
+    public function __invoke(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $token = $this->tokenStorage->getToken();
+        if (!$token instanceof \Symfony\Component\Security\Core\Authentication\Token\TokenInterface) {
+            return;
+        }
+
+        $user = $token->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        if (!$user->isMustChangePassword()) {
+            return;
+        }
+
+        $currentRoute = $event->getRequest()->attributes->get('_route');
+        if (\in_array($currentRoute, self::EXCLUDED_ROUTES, true)) {
+            return;
+        }
+
+        $url = $this->router->generate('user_force_change_password');
+        $event->setResponse(new RedirectResponse($url));
+    }
+}

--- a/src/Form/AdminUserCreateType.php
+++ b/src/Form/AdminUserCreateType.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Entity\User;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * Formulaire de création d'utilisateur par un administrateur.
+ * Le mot de passe est généré automatiquement — seul l'email est saisi.
+ *
+ * @extends AbstractType<User>
+ */
+class AdminUserCreateType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('email', EmailType::class, [
+            'label' => 'Adresse email',
+            'constraints' => [
+                new NotBlank(message: 'Veuillez entrer une adresse email.'),
+                new Email(message: "L'adresse email n'est pas valide."),
+                new Length(max: 180, maxMessage: "L'adresse email ne peut pas dépasser {{ limit }} caractères."),
+            ],
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => User::class,
+        ]);
+    }
+}

--- a/src/Form/ForceChangePasswordType.php
+++ b/src/Form/ForceChangePasswordType.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\PasswordStrength;
+
+/**
+ * Formulaire de changement de mot de passe forcé (première connexion).
+ *
+ * Ne demande pas l'ancien mot de passe : celui-ci a été généré aléatoirement
+ * par l'administrateur et l'utilisateur n'est pas censé le conserver.
+ *
+ * @extends AbstractType<mixed>
+ */
+class ForceChangePasswordType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('plainPassword', RepeatedType::class, [
+            'type' => PasswordType::class,
+            'options' => [
+                'attr' => ['autocomplete' => 'new-password'],
+            ],
+            'first_options' => [
+                'label' => 'Nouveau mot de passe',
+                'constraints' => [
+                    new NotBlank(message: 'Veuillez saisir un nouveau mot de passe.'),
+                    new Length(
+                        min: 12,
+                        max: 4096,
+                        minMessage: 'Votre mot de passe doit contenir au moins {{ limit }} caractères.',
+                    ),
+                    new PasswordStrength(),
+                ],
+            ],
+            'second_options' => [
+                'label' => 'Confirmez votre mot de passe',
+            ],
+            'invalid_message' => 'Les deux mots de passe doivent être identiques.',
+            'mapped' => false,
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([]);
+    }
+}

--- a/src/Security/LoginAuthenticationSuccessHandler.php
+++ b/src/Security/LoginAuthenticationSuccessHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Security;
+
+use App\Entity\User;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+
+/**
+ * Gère la redirection après une authentification réussie.
+ *
+ * Si l'utilisateur a mustChangePassword = true, il est redirigé vers la page
+ * de changement de mot de passe obligatoire (/profile/password/force).
+ *
+ * Sinon, il est redirigé vers la page demandée ou vers l'accueil.
+ */
+final readonly class LoginAuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterface
+{
+    public function __construct(
+        private RouterInterface $router,
+    ) {
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token): RedirectResponse
+    {
+        $user = $token->getUser();
+
+        if ($user instanceof User && $user->isMustChangePassword()) {
+            return new RedirectResponse(
+                $this->router->generate('user_force_change_password')
+            );
+        }
+
+        $targetPath = $request->getSession()->get('_security.main.target_path');
+        if ($targetPath) {
+            $request->getSession()->remove('_security.main.target_path');
+
+            return new RedirectResponse($targetPath);
+        }
+
+        return new RedirectResponse($this->router->generate('app_home'));
+    }
+}

--- a/src/Security/UserPermissionService.php
+++ b/src/Security/UserPermissionService.php
@@ -16,6 +16,11 @@ final class UserPermissionService
     // Gestion des utilisateurs
     // -----------------------------------------------------------------------
 
+    public function canCreateUser(User $user): bool
+    {
+        return $this->hasAnyRole($user, UserRole::ADMIN);
+    }
+
     public function canAccessUserManagement(User $user): bool
     {
         return $this->hasAtLeastRole($user, UserRole::CLUB_PRESIDENT);

--- a/src/Security/Voter/UserPermissionVoter.php
+++ b/src/Security/Voter/UserPermissionVoter.php
@@ -22,6 +22,8 @@ final class UserPermissionVoter extends Voter
     // Gestion des utilisateurs
     public const string ACCESS_USER_MANAGEMENT = 'ACCESS_USER_MANAGEMENT';
 
+    public const string CREATE_USER = 'CREATE_USER';
+
     public const string EDIT_OWN_ACCOUNT_INFORMATION = 'EDIT_OWN_ACCOUNT_INFORMATION';
 
     public const string ASSIGN_USER_TO_ANY_CLUB = 'ASSIGN_USER_TO_ANY_CLUB';
@@ -89,6 +91,7 @@ final class UserPermissionVoter extends Voter
      */
     private const array ROLE_ONLY_ATTRIBUTES = [
         self::ACCESS_USER_MANAGEMENT => 'canAccessUserManagement',
+        self::CREATE_USER => 'canCreateUser',
         self::EDIT_OWN_ACCOUNT_INFORMATION => 'canEditOwnAccountInformation',
         self::ASSIGN_USER_TO_ANY_CLUB => 'canAssignUserToAnyClub',
         self::ASSIGN_USER_TO_OWN_CLUB => 'canAssignUserToOwnClub',

--- a/src/Service/EquipmentExportService.php
+++ b/src/Service/EquipmentExportService.php
@@ -6,7 +6,7 @@ namespace App\Service;
 
 use App\Entity\Equipment;
 use App\Entity\Etafoam;
-use App\Entity\Glove;
+use App\Entity\Gake;
 use App\Entity\Maku;
 use App\Entity\Makiwara;
 use App\Entity\SupportMakiwara;
@@ -76,8 +76,8 @@ final readonly class EquipmentExportService
             'Matériau',           // Yumi, Makiwara, Maku
             'Force (kg)',         // Yumi
             'Longueur arc',       // Yumi
-            'Nb doigts',          // Glove
-            'Taille gant',        // Glove
+            'Nb doigts',          // Gake
+            'Taille gant',        // Gake
             'Hauteur (cm)',       // SupportMakiwara, Maku
             'Nb arcs',            // Yumitate
             'Orientation',        // Yumitate
@@ -113,7 +113,7 @@ final readonly class EquipmentExportService
             $this->extractYumiStrength($equipment),
             $this->extractYumiLength($equipment),
             $this->extractNbFingers($equipment),
-            $this->extractGloveSize($equipment),
+            $this->extractGakeSize($equipment),
             $this->extractHeight($equipment),
             $this->extractNbBows($equipment),
             $this->extractYumitateOrientation($equipment),
@@ -181,16 +181,16 @@ final readonly class EquipmentExportService
 
     private function extractNbFingers(Equipment $equipment): string
     {
-        if (!$equipment instanceof Glove) {
+        if (!$equipment instanceof Gake) {
             return '';
         }
 
         return (string) ($equipment->getNbFingers() ?? '');
     }
 
-    private function extractGloveSize(Equipment $equipment): string
+    private function extractGakeSize(Equipment $equipment): string
     {
-        if (!$equipment instanceof Glove) {
+        if (!$equipment instanceof Gake) {
             return '';
         }
 

--- a/src/Service/PasswordGenerator.php
+++ b/src/Service/PasswordGenerator.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+/**
+ * Génère un mot de passe aléatoire sécurisé respectant les contraintes :
+ *   - 12 caractères
+ *   - Au moins 1 lettre majuscule (A-Z)
+ *   - Au moins 1 caractère spécial ($, #, !, @, &, *, %)
+ *   - Le reste est composé de caractères alphanumériques
+ */
+final class PasswordGenerator
+{
+    private const string UPPERCASE = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    private const string LOWERCASE = 'abcdefghijklmnopqrstuvwxyz';
+
+    private const string DIGITS = '0123456789';
+
+    private const string SPECIAL = '$#!@&*%';
+
+    public function generate(int $length = 12): string
+    {
+        $password = [];
+
+        // Garantit au moins 1 majuscule
+        $password[] = $this->randomChar(self::UPPERCASE);
+
+        // Garantit au moins 1 caractère spécial
+        $password[] = $this->randomChar(self::SPECIAL);
+
+        // Complète avec des caractères alphanumériques
+        $alphanumeric = self::UPPERCASE.self::LOWERCASE.self::DIGITS;
+        for ($i = 0; $i < $length - 2; ++$i) {
+            $password[] = $this->randomChar($alphanumeric);
+        }
+
+        // Mélange pour éviter un motif prévisible (majuscule toujours en 1ère position)
+        shuffle($password);
+
+        return implode('', $password);
+    }
+
+    private function randomChar(string $chars): string
+    {
+        $max = \strlen($chars) - 1;
+        if ($max < 0) {
+            throw new \InvalidArgumentException('La chaîne de caractères source ne peut pas être vide.');
+        }
+
+        return $chars[random_int(0, $max)];
+    }
+}

--- a/templates/admin/user/create-success.html.twig
+++ b/templates/admin/user/create-success.html.twig
@@ -1,0 +1,116 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Utilisateur créé{% endblock %}
+
+{% block body %}
+	<div class="h-screen-with-navbar bg-kyudo-club px-4 pb-10 pt-16 sm:px-6">
+		<div class="mx-auto max-w-3xl rounded-[32px] bg-kyudo-white/95 p-6 shadow-2xl ring-1 ring-black/5 backdrop-blur sm:p-8 md:p-10">
+
+			<div class="space-y-6">
+				<!-- Success message -->
+				{% include 'partials/_alert.html.twig' with {
+					type: 'success',
+					title: 'Utilisateur créé avec succès',
+					message: 'Veuillez communiquer les identifiants ci-dessous au nouvel utilisateur. Il devra modifier son mot de passe lors de sa première connexion.',
+					class: 'mb-6'
+				} only %}
+
+				<!-- Credentials section -->
+				<section class="rounded-3xl border border-kyudo-gm-light-grey bg-kyudo-white p-6 shadow-sm">
+					<h1 class="text-2xl font-semibold tracking-tight text-kyudo-gm-dark">Identifiants à communiquer</h1>
+
+					<div class="mt-6 space-y-4">
+						<!-- Email -->
+						<div class="rounded-2xl bg-kyudo-gm-light-grey p-4">
+							<p class="text-sm font-medium text-kyudo-gm-grey">Adresse email</p>
+							<div class="mt-3 flex items-center justify-between">
+								<p class="font-mono text-base font-semibold text-kyudo-gm-dark">{{ email }}</p>
+								<button
+									type="button"
+									class="btn btn-secondary btn-sm"
+									onclick="copyToClipboard('{{ email }}', this)"
+									title="Copier l'email"
+								>
+									Copier
+								</button>
+							</div>
+						</div>
+
+						<!-- Password -->
+						<div class="rounded-2xl bg-kyudo-gm-light-grey p-4">
+							<div class="flex items-center justify-between">
+								<p class="text-sm font-medium text-kyudo-gm-grey">Mot de passe temporaire</p>
+								<button
+									type="button"
+									id="toggle-password-btn"
+									class="text-sm text-kyudo-royal-blue hover:text-kyudo-blue"
+									onclick="togglePasswordVisibility()"
+									title="Afficher/masquer le mot de passe"
+								>
+									Afficher
+								</button>
+							</div>
+							<div class="mt-3 flex items-center justify-between">
+								<p id="password-display" class="font-mono text-base font-semibold text-kyudo-gm-dark">••••••••••••</p>
+								<button
+									type="button"
+									class="btn btn-primary btn-sm"
+									onclick="copyToClipboard('{{ plainPassword }}', this)"
+									title="Copier le mot de passe"
+								>
+									Copier
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<!-- Warning -->
+					<div class="mt-6 rounded-2xl border border-orange-200 bg-orange-50/40 p-4">
+						<p class="text-sm text-orange-800">
+							<strong>⚠️ Important :</strong> Cette page ne s'affichera qu'une seule fois. Notez le mot de passe avant de continuer.
+							L'utilisateur devra le modifier à sa première connexion.
+						</p>
+					</div>
+				</section>
+
+				<!-- Action buttons -->
+				<div class="flex flex-col gap-3 sm:flex-row">
+					<a class="btn btn-primary" href="{{ path('user_index') }}">Retour à la gestion des utilisateurs</a>
+					<a class="btn btn-secondary" href="{{ path('admin_user_create') }}">Créer un autre utilisateur</a>
+				</div>
+			</div>
+		</div>
+	</div>
+
+	<script>
+		let passwordVisible = false;
+		const plainPassword = '{{ plainPassword|escape('js') }}';
+
+		function togglePasswordVisibility() {
+			passwordVisible = !passwordVisible;
+			const display = document.getElementById('password-display');
+			const btn = document.getElementById('toggle-password-btn');
+
+			if (passwordVisible) {
+				display.textContent = plainPassword;
+				btn.textContent = 'Masquer';
+			} else {
+				display.textContent = '••••••••••••';
+				btn.textContent = 'Afficher';
+			}
+		}
+
+		function copyToClipboard(text, button) {
+			navigator.clipboard.writeText(text).then(() => {
+				const originalText = button.textContent;
+				button.textContent = '✓ Copié !';
+				button.disabled = true;
+
+				setTimeout(() => {
+					button.textContent = originalText;
+					button.disabled = false;
+				}, 2000);
+			});
+		}
+	</script>
+{% endblock %}

--- a/templates/admin/user/create.html.twig
+++ b/templates/admin/user/create.html.twig
@@ -1,0 +1,90 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Créer un utilisateur{% endblock %}
+
+{% block body %}
+	{% set defaultFieldClass = 'block w-full rounded-xl border border-gray-300 px-3 py-2 focus:border-kyudo-royal-blue focus:outline-none focus:ring-2 focus:ring-kyudo-royal-blue' %}
+	{% set invalidFieldClass = 'block w-full rounded-xl border border-red-300 bg-red-50/40 px-3 py-2 focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500' %}
+
+	<div class="h-screen-with-navbar bg-kyudo-club px-4 pb-10 pt-16 sm:px-6">
+		<div class="mx-auto max-w-5xl rounded-[32px] bg-kyudo-white/95 p-6 shadow-2xl ring-1 ring-black/5 backdrop-blur sm:p-8 md:p-10">
+
+			{% for message in app.flashes('success') %}
+				{% include 'partials/_alert.html.twig' with {
+					type: 'success',
+					title: message,
+					class: 'mb-6'
+				} only %}
+			{% endfor %}
+
+			<div class="grid gap-6 lg:grid-cols-[1.3fr_0.9fr]">
+				<section class="rounded-3xl border border-kyudo-gm-light-grey bg-kyudo-white p-6 shadow-sm">
+					<h1 class="text-3xl font-semibold tracking-tight text-kyudo-gm-dark">Créer un utilisateur</h1>
+					<p class="mt-3 max-w-2xl text-sm leading-6 text-kyudo-gm-grey">
+						Saisissez l'adresse email du nouvel utilisateur. Un mot de passe temporaire sécurisé sera généré automatiquement.
+						L'utilisateur sera invité à le modifier dès sa première connexion.
+					</p>
+
+					<div class="mt-8 max-w-2xl">
+						{{ form_start(form) }}
+
+						{% if form.vars.errors|length %}
+							{% include 'partials/_alert.html.twig' with {
+								type: 'error',
+								title: 'La création ne peut pas encore être enregistrée.',
+								errors: form.vars.errors,
+								class: 'mb-5'
+							} only %}
+						{% endif %}
+
+						<div>
+							<label for="{{ form.email.vars.id }}" class="mb-1 block text-sm font-medium text-kyudo-gm-grey">
+								{{ form.email.vars.label|default('Adresse email') }}
+							</label>
+							{{ form_widget(form.email, {
+								attr: {
+									class: form.email.vars.errors|length ? invalidFieldClass : defaultFieldClass,
+									placeholder: 'prenom.nom@exemple.fr'
+								}
+							}) }}
+							{% if form.email.vars.errors|length %}
+								{% include 'partials/_alert.html.twig' with {
+									type: 'error',
+									label: 'Champ invalide',
+									errors: form.email.vars.errors,
+									class: 'mt-3'
+								} only %}
+							{% endif %}
+						</div>
+
+						<div class="mt-6 flex flex-col gap-3 sm:flex-row">
+							<button type="submit" class="btn btn-primary">Créer l'utilisateur</button>
+							<a class="btn btn-secondary" href="{{ path('user_index') }}">Retour à la liste</a>
+						</div>
+
+						{{ form_end(form) }}
+					</div>
+				</section>
+
+				<aside class="rounded-3xl border border-kyudo-gm-light-grey bg-kyudo-gm-light-grey p-6 shadow-sm">
+					<h2 class="text-xl font-semibold text-kyudo-gm-dark">Informations</h2>
+
+					<div class="mt-4 rounded-2xl bg-kyudo-white p-4 shadow-sm">
+						<p class="text-sm font-medium text-kyudo-gm-grey">Mot de passe</p>
+						<p class="mt-2 text-sm leading-6 text-kyudo-gm-grey">
+							Un mot de passe de 12 caractères (majuscule + caractère spécial) est généré automatiquement.
+							L'utilisateur devra le modifier à sa première connexion.
+						</p>
+					</div>
+
+					<div class="mt-4 rounded-2xl bg-kyudo-white p-4 shadow-sm">
+						<p class="text-sm font-medium text-kyudo-gm-grey">Rôle attribué</p>
+						<p class="mt-2 text-sm leading-6 text-kyudo-gm-grey">
+							Le compte est créé avec le rôle <strong>Utilisateur</strong>. Vous pourrez lui attribuer un rôle supérieur depuis la gestion des utilisateurs.
+						</p>
+					</div>
+				</aside>
+			</div>
+		</div>
+	</div>
+{% endblock %}

--- a/templates/user/force_change_password.html.twig
+++ b/templates/user/force_change_password.html.twig
@@ -1,0 +1,102 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Définir votre mot de passe{% endblock %}
+
+{% block body %}
+	{% set defaultFieldClass = 'block w-full rounded-xl border border-gray-300 px-3 py-2 focus:border-kyudo-royal-blue focus:outline-none focus:ring-2 focus:ring-kyudo-royal-blue' %}
+	{% set invalidFieldClass = 'block w-full rounded-xl border border-red-300 bg-red-50/40 px-3 py-2 focus:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-500' %}
+
+	<div class="h-screen-with-navbar bg-kyudo-club px-4 pb-10 pt-16 sm:px-6">
+		<div class="mx-auto max-w-5xl rounded-[32px] bg-kyudo-white/95 p-6 shadow-2xl ring-1 ring-black/5 backdrop-blur sm:p-8 md:p-10">
+			<div class="grid gap-6 lg:grid-cols-[1.3fr_0.9fr]">
+				<section class="rounded-3xl border border-kyudo-gm-light-grey bg-kyudo-white p-6 shadow-sm">
+					<h1 class="text-3xl font-semibold tracking-tight text-kyudo-gm-dark">Définissez votre mot de passe</h1>
+					<p class="mt-3 max-w-2xl text-sm leading-6 text-kyudo-gm-grey">
+						Votre compte a été créé par un administrateur. Pour des raisons de sécurité, vous devez définir votre propre mot de passe avant de continuer.
+					</p>
+
+					<div class="mt-8 max-w-2xl">
+						{{ form_start(form) }}
+
+						{% if form.vars.errors|length %}
+							{% include 'partials/_alert.html.twig' with {
+								type: 'error',
+								title: 'Le mot de passe doit être corrigé.',
+								errors: form.vars.errors,
+								class: 'mb-5'
+							} only %}
+						{% endif %}
+
+						{% if form.plainPassword.vars.errors|length %}
+							{% include 'partials/_alert.html.twig' with {
+								type: 'warning',
+								title: 'Le nouveau mot de passe doit être corrigé.',
+								errors: form.plainPassword.vars.errors,
+								class: 'mb-5'
+							} only %}
+						{% endif %}
+
+						<div class="space-y-5">
+							<div>
+								<label for="{{ form.plainPassword.first.vars.id }}" class="mb-1 block text-sm font-medium text-kyudo-gm-grey">
+									{{ form.plainPassword.first.vars.label|default('Nouveau mot de passe') }}
+								</label>
+								{{ form_widget(form.plainPassword.first, {
+									attr: {
+										class: (form.plainPassword.first.vars.errors|length or form.plainPassword.vars.errors|length) ? invalidFieldClass : defaultFieldClass
+									}
+								}) }}
+								{% if form.plainPassword.first.vars.errors|length %}
+									{% include 'partials/_alert.html.twig' with {
+										type: 'error',
+										label: 'Champ invalide',
+										errors: form.plainPassword.first.vars.errors,
+										class: 'mt-3'
+									} only %}
+								{% endif %}
+							</div>
+
+							<div>
+								<label for="{{ form.plainPassword.second.vars.id }}" class="mb-1 block text-sm font-medium text-kyudo-gm-grey">
+									{{ form.plainPassword.second.vars.label|default('Confirmez votre mot de passe') }}
+								</label>
+								{{ form_widget(form.plainPassword.second, {
+									attr: {
+										class: (form.plainPassword.second.vars.errors|length or form.plainPassword.vars.errors|length) ? invalidFieldClass : defaultFieldClass
+									}
+								}) }}
+								{% if form.plainPassword.second.vars.errors|length %}
+									{% include 'partials/_alert.html.twig' with {
+										type: 'error',
+										label: 'Champ invalide',
+										errors: form.plainPassword.second.vars.errors,
+										class: 'mt-3'
+									} only %}
+								{% endif %}
+							</div>
+						</div>
+
+						<div class="mt-6">
+							<button type="submit" class="btn btn-primary">Enregistrer</button>
+						</div>
+
+						{{ form_end(form) }}
+					</div>
+				</section>
+
+				<aside class="rounded-3xl border border-kyudo-gm-light-grey bg-kyudo-gm-light-grey p-6 shadow-sm">
+					<h2 class="text-xl font-semibold text-kyudo-gm-dark">Conseils</h2>
+					<div class="mt-4 rounded-2xl bg-kyudo-white p-4 shadow-sm">
+						<p class="text-sm font-medium text-kyudo-gm-grey">Bonnes pratiques</p>
+						<ul class="mt-3 space-y-2 text-sm leading-6 text-kyudo-gm-grey">
+							<li>Utilisez au moins 12 caractères.</li>
+							<li>Combinez majuscules, minuscules, chiffres et caractères spéciaux.</li>
+							<li>Évitez les mots courants ou des informations personnelles.</li>
+							<li>Conservez votre mot de passe dans un gestionnaire sécurisé.</li>
+						</ul>
+					</div>
+				</aside>
+			</div>
+		</div>
+	</div>
+{% endblock %}

--- a/templates/user/index.html.twig
+++ b/templates/user/index.html.twig
@@ -19,6 +19,9 @@
 						{{ users|length }}
 						utilisateur{{ users|length > 1 ? 's' : '' }}
 					</div>
+					{% if is_granted('CREATE_USER') %}
+						<a class="btn btn-primary" href="{{ path('admin_user_create') }}">Créer un utilisateur</a>
+					{% endif %}
 					<a class="btn btn-secondary" data-history-back href="{{ path('user_profile') }}">Retour au profil</a>
 				</div>
 			</div>

--- a/tests/Functional/AdminUserCreationTest.php
+++ b/tests/Functional/AdminUserCreationTest.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\DataFixtures\AppFixtures;
+use App\Entity\User;
+use App\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+
+/**
+ * Tests fonctionnels : AdminUserController — Création d'utilisateur par un administrateur.
+ *
+ * Routes testées :
+ *   GET  /admin/users/create → CREATE_USER (ADMIN uniquement)
+ *   POST /admin/users/create → CREATE_USER (ADMIN uniquement)
+ *   GET  /profile/password/force → EDIT_OWN_ACCOUNT_INFORMATION (utilisateur avec mustChangePassword)
+ *   POST /profile/password/force → EDIT_OWN_ACCOUNT_INFORMATION
+ *
+ * Règles métier :
+ *   - Seul ROLE_ADMIN peut créer un utilisateur
+ *   - Le mot de passe est généré aléatoirement (12 car., 1 majuscule, 1 spécial)
+ *   - Le nouvel utilisateur reçoit ROLE_USER et mustChangePassword = true
+ *   - À la première connexion, l'utilisateur est redirigé vers /profile/password/force
+ *   - Après avoir changé son mot de passe, mustChangePassword passe à false
+ */
+final class AdminUserCreationTest extends AbstractWebTestCase
+{
+    // -----------------------------------------------------------------------
+    // GET /admin/users/create — accès réservé à ROLE_ADMIN
+    // -----------------------------------------------------------------------
+
+    public function testAdminCanAccessCreateUserPage(): void
+    {
+        $this->loginAs(AppFixtures::USER_ADMIN);
+        $this->assertGetGranted('/admin/users/create');
+    }
+
+    public function testRoleUserCannotAccessCreateUserPage(): void
+    {
+        $this->loginAs(AppFixtures::USER_USER);
+        $this->assertGetDenied('/admin/users/create');
+    }
+
+    public function testMemberCannotAccessCreateUserPage(): void
+    {
+        $this->loginAs(AppFixtures::USER_MEMBER);
+        $this->assertGetDenied('/admin/users/create');
+    }
+
+    public function testPresidentCannotAccessCreateUserPage(): void
+    {
+        $this->loginAs(AppFixtures::USER_PRESIDENT);
+        $this->assertGetDenied('/admin/users/create');
+    }
+
+    public function testManagerClubCannotAccessCreateUserPage(): void
+    {
+        $this->loginAs(AppFixtures::USER_MANAGER_CLUB);
+        $this->assertGetDenied('/admin/users/create');
+    }
+
+    public function testManagerCtkCannotAccessCreateUserPage(): void
+    {
+        $this->loginAs(AppFixtures::USER_MANAGER_CTK);
+        $this->assertGetDenied('/admin/users/create');
+    }
+
+    public function testManagerCnCannotAccessCreateUserPage(): void
+    {
+        $this->loginAs(AppFixtures::USER_MANAGER_CN);
+        $this->assertGetDenied('/admin/users/create');
+    }
+
+    // -----------------------------------------------------------------------
+    // POST /admin/users/create — création effective
+    // -----------------------------------------------------------------------
+
+    public function testAdminCanCreateUserWithValidEmail(): void
+    {
+        $this->loginAs(AppFixtures::USER_ADMIN);
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/admin/users/create');
+        $form = $crawler->selectButton('Créer l\'utilisateur')->form();
+        $form['admin_user_create[email]'] = 'newuser@kyudo-test.fr';
+
+        $this->client->submit($form);
+
+        // Après la création, on doit être redirigé vers la page de succès
+        $this->assertResponseRedirects('/admin/users/create/success');
+
+        $container = self::getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get(EntityManagerInterface::class);
+        $em->clear();
+
+        /** @var UserRepository $userRepo */
+        $userRepo = $container->get(UserRepository::class);
+        $newUser = $userRepo->findOneBy(['email' => 'newuser@kyudo-test.fr']);
+
+        $this->assertInstanceOf(User::class, $newUser);
+        $this->assertContains('ROLE_USER', $newUser->getRoles());
+        $this->assertTrue($newUser->isMustChangePassword());
+    }
+
+    public function testAdminCanSeeGeneratedPasswordOnSuccessPage(): void
+    {
+        $this->loginAs(AppFixtures::USER_ADMIN);
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/admin/users/create');
+        $form = $crawler->selectButton('Créer l\'utilisateur')->form();
+        $newUserEmail = 'newuser-with-password@kyudo-test.fr';
+        $form['admin_user_create[email]'] = $newUserEmail;
+
+        $this->client->submit($form);
+
+        // Suivre la redirection vers la page de succès
+        $this->client->followRedirect();
+        $this->assertResponseIsSuccessful();
+
+        // Vérifier que la page contient l'email du nouvel utilisateur
+        $this->assertStringContainsString($newUserEmail, (string) $this->client->getResponse()->getContent());
+
+        // Vérifier que la page contient un formulaire ou du contenu pour afficher le mot de passe
+        $content = $this->client->getResponse()->getContent();
+        $this->assertStringContainsString('Identifiants à communiquer', (string) $content);
+        $this->assertStringContainsString('Mot de passe temporaire', (string) $content);
+    }
+
+    public function testSuccessPageIsOnlyAccessibleAfterCreation(): void
+    {
+        $this->loginAs(AppFixtures::USER_ADMIN);
+
+        // Accès direct à la page de succès sans avoir créé d'utilisateur
+        $this->client->request(Request::METHOD_GET, '/admin/users/create/success');
+
+        // Doit rediriger vers la page de création
+        $this->assertResponseRedirects('/admin/users/create');
+    }
+
+    public function testCreatingUserWithExistingEmailFails(): void
+    {
+        $this->loginAs(AppFixtures::USER_ADMIN);
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/admin/users/create');
+        $form = $crawler->selectButton('Créer l\'utilisateur')->form();
+        $form['admin_user_create[email]'] = AppFixtures::USER_USER;
+
+        $this->client->submit($form);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    public function testCreatingUserWithInvalidEmailFails(): void
+    {
+        $this->loginAs(AppFixtures::USER_ADMIN);
+
+        $crawler = $this->client->request(Request::METHOD_GET, '/admin/users/create');
+        $form = $crawler->selectButton('Créer l\'utilisateur')->form();
+        $form['admin_user_create[email]'] = 'pas-un-email';
+
+        $this->client->submit($form);
+        $this->assertResponseStatusCodeSame(422);
+    }
+
+    // -----------------------------------------------------------------------
+    // Listener : redirection forcée vers /profile/password/force
+    // -----------------------------------------------------------------------
+
+    public function testUserWithMustChangePasswordIsRedirectedOnProfileAccess(): void
+    {
+        $user = $this->createUserWithMustChangePassword('must-change-1@kyudo-test.fr');
+        $this->client->loginUser($user);
+
+        $this->client->request(Request::METHOD_GET, '/profile');
+
+        $this->assertResponseRedirects('/profile/password/force');
+    }
+
+    public function testUserWithMustChangePasswordIsRedirectedOnUserIndexAccess(): void
+    {
+        // On crée un admin avec mustChangePassword pour vérifier la redirection même pour les admins
+        $user = $this->createUserWithMustChangePassword('must-change-admin@kyudo-test.fr', ['ROLE_ADMIN']);
+        $this->client->loginUser($user);
+
+        $this->client->request(Request::METHOD_GET, '/user');
+
+        $this->assertResponseRedirects('/profile/password/force');
+    }
+
+    public function testUserWithoutMustChangePasswordIsNotRedirected(): void
+    {
+        $this->loginAs(AppFixtures::USER_USER);
+
+        $this->client->request(Request::METHOD_GET, '/profile');
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    // -----------------------------------------------------------------------
+    // GET /profile/password/force — accessible à l'utilisateur concerné
+    // -----------------------------------------------------------------------
+
+    public function testForceChangePasswordPageIsAccessibleWhenRequired(): void
+    {
+        $user = $this->createUserWithMustChangePassword('must-change-2@kyudo-test.fr');
+        $this->client->loginUser($user);
+
+        $this->client->request(Request::METHOD_GET, '/profile/password/force');
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testForceChangePasswordPageRedirectsToProfileIfNotRequired(): void
+    {
+        $this->loginAs(AppFixtures::USER_USER);
+
+        $this->client->request(Request::METHOD_GET, '/profile/password/force');
+
+        $this->assertResponseRedirects('/profile');
+    }
+
+    // -----------------------------------------------------------------------
+    // POST /profile/password/force — changement effectif, mustChangePassword → false
+    // -----------------------------------------------------------------------
+
+    public function testUserCanChangePasswordAndAccessAppNormally(): void
+    {
+        $container = self::getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get(EntityManagerInterface::class);
+
+        $user = $this->createUserWithMustChangePassword('must-change-3@kyudo-test.fr');
+        $this->client->loginUser($user);
+
+        // Accès à la page de changement forcé
+        $crawler = $this->client->request(Request::METHOD_GET, '/profile/password/force');
+        $this->assertResponseIsSuccessful();
+
+        // Soumission du nouveau mot de passe
+        $form = $crawler->selectButton('Enregistrer')->form();
+        $form['force_change_password[plainPassword][first]']  = 'NouveauMotDePasse9@';
+        $form['force_change_password[plainPassword][second]'] = 'NouveauMotDePasse9@';
+        $this->client->submit($form);
+
+        $this->assertResponseRedirects('/profile');
+
+        // Vérification en base : mustChangePassword est passé à false
+        $em->clear();
+        /** @var UserRepository $userRepo */
+        $userRepo = $container->get(UserRepository::class);
+        $updated = $userRepo->findOneBy(['email' => 'must-change-3@kyudo-test.fr']);
+        $this->assertInstanceOf(User::class, $updated);
+        $this->assertFalse($updated->isMustChangePassword());
+
+        // L'utilisateur peut désormais accéder normalement au profil (sans redirection)
+        $this->client->request(Request::METHOD_GET, '/profile');
+        $this->assertResponseIsSuccessful();
+    }
+
+    // -----------------------------------------------------------------------
+    // Intégration complète : création, première connexion et changement de mot de passe
+    // -----------------------------------------------------------------------
+
+    public function testNewUserCreatedAdminCanViewAndLoginRequiresPasswordChange(): void
+    {
+        // Step 1: L'admin crée un nouvel utilisateur via le formulaire
+        $this->loginAs(AppFixtures::USER_ADMIN);
+        $newUserEmail = 'brand-new-user@kyudo-test.fr';
+
+        $this->assertFormSubmitRedirects(
+            '/admin/users/create',
+            'Créer l\'utilisateur',
+            ['admin_user_create[email]' => $newUserEmail],
+        );
+
+        $container = self::getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get(EntityManagerInterface::class);
+        /** @var UserRepository $userRepo */
+        $userRepo = $container->get(UserRepository::class);
+
+        // Step 2: Vérifier que l'utilisateur a été créé avec mustChangePassword = true
+        $em->clear();
+        $newUser = $userRepo->findOneBy(['email' => $newUserEmail]);
+        $this->assertInstanceOf(User::class, $newUser);
+        $this->assertTrue($newUser->isMustChangePassword(), 'Le nouvel utilisateur doit avoir mustChangePassword = true');
+        $this->assertContains('ROLE_USER', $newUser->getRoles(), 'Le nouvel utilisateur doit avoir ROLE_USER');
+    }
+
+    // -----------------------------------------------------------------------
+    // Intégration : création d'utilisateur + connexion + redirection obligatoire
+    // -----------------------------------------------------------------------
+
+    public function testNewUserIsRedirectedToPasswordChangeOnLogin(): void
+    {
+        $this->loginAs(AppFixtures::USER_ADMIN);
+
+        // Créer un nouvel utilisateur
+        $newUserEmail = 'redirect-test@kyudo-test.fr';
+        $crawler = $this->client->request(Request::METHOD_GET, '/admin/users/create');
+        $form = $crawler->selectButton('Créer l\'utilisateur')->form();
+        $form['admin_user_create[email]'] = $newUserEmail;
+
+        $this->client->submit($form);
+
+        // Récupérer le mot de passe depuis la session AVANT redirection
+        $session = $this->client->getRequest()->getSession();
+        $sessionData = $session->get('admin_user_created');
+        $plainPassword = $sessionData['plainPassword'];
+
+        // Suivre la redirection vers la page de succès
+        $this->client->followRedirect();
+        $this->assertResponseIsSuccessful();
+
+        // Se déconnecter
+        $this->client->request(Request::METHOD_GET, '/logout');
+
+        // Se connecter avec le nouvel utilisateur et le mot de passe généré
+        $crawler = $this->client->request(Request::METHOD_GET, '/login');
+        $form = $crawler->selectButton('Se connecter')->form();
+        $form['_username'] = $newUserEmail;
+        $form['_password'] = $plainPassword;
+
+        $this->client->submit($form);
+
+        // Vérifier que l'utilisateur est redirigé vers /profile/password/force
+        $this->assertResponseRedirects('/profile/password/force');
+
+        // Suivre la redirection pour vérifier que la page est accessible
+        $this->client->followRedirect();
+        $this->assertResponseIsSuccessful();
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Crée et persiste un utilisateur avec mustChangePassword = true dans la transaction DAMA.
+     *
+     * @param list<string> $roles
+     */
+    private function createUserWithMustChangePassword(string $email, array $roles = []): User
+    {
+        $container = self::getContainer();
+        /** @var EntityManagerInterface $em */
+        $em = $container->get(EntityManagerInterface::class);
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = $container->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setPassword($hasher->hashPassword($user, 'TempGen#Pass1'));
+        $user->setMustChangePassword(true);
+        $user->setRoles($roles);
+
+        $em->persist($user);
+        $em->flush();
+
+        return $user;
+    }
+}

--- a/tests/Functional/EquipmentControllerTest.php
+++ b/tests/Functional/EquipmentControllerTest.php
@@ -71,7 +71,7 @@ final class EquipmentControllerTest extends AbstractWebTestCase
     /** ID du gant appartenant au Club C (sans président, Région A — même région que Club A) */
     private int $gakeCId;
 
-    /** ID du gant appartenant au Club G (Bretagne, Région C — autre CTK) */
+    /** ID du gant appartenant au Club G (Arc Atlantique, Région C — autre CTK) */
     private int $gakeGId;
 
     /** ID du gant régional (owner_region = Région A) — disponible */
@@ -80,7 +80,7 @@ final class EquipmentControllerTest extends AbstractWebTestCase
     /** ID du gant régional (owner_region = Région A) — emprunté */
     private int $gakeRegionalBorrowedId;
 
-    /** ID du gant régional (owner_region = Bretagne / Région C) — disponible */
+    /** ID du gant régional (owner_region = Arc Atlantique / Région C) — disponible */
     private int $gakeRegionalCId;
 
     /** ID du gant national (owner_federation = Fédération) — disponible */
@@ -120,7 +120,7 @@ final class EquipmentControllerTest extends AbstractWebTestCase
                 } else {
                     $this->gakeRegionalBorrowedId = $gake->getId();
                 }
-            } elseif ('Bretagne' === $gake->getOwnerRegion()?->getName()) {
+            } elseif (AppFixtures::REGION_C === $gake->getOwnerRegion()?->getName()) {
                 $this->gakeRegionalCId = $gake->getId();
             } elseif ($gake->getOwnerFederation() instanceof Federation) {
                 // Deux gants nationaux : disponible et emprunté
@@ -188,10 +188,10 @@ final class EquipmentControllerTest extends AbstractWebTestCase
     // liens de la liste paginée.
     //
     // Rappel des fixtures :
-    //   Club A (Région A / Île-de-France) — member, president, mgr-club
+    //   Club A (Région A / Ile de France) — member, president, mgr-club
     //   Club B (Région B)                 — emprunté par Club C
     //   Club C (Région A)                 — disponible
-    //   Club G (Région C / Bretagne)      — disponible
+    //   Club G (Région C / Arc Atlantique) — disponible
     //   Régional Région A dispo           — gakeRegionalId
     //   Régional Région A emprunté        — gakeRegionalBorrowedId
     //   Régional Région C dispo           — gakeRegionalCId
@@ -354,7 +354,7 @@ final class EquipmentControllerTest extends AbstractWebTestCase
 
     public function testIndexMgrCtkDoesNotSeeOtherCtkBorrowedClub(): void
     {
-        // Club B (Région B) a son gant emprunté → CTK Île-de-France ne peut pas le voir
+        // Club B (Région B) a son gant emprunté → CTK Ile de France ne peut pas le voir
         $this->loginAs(AppFixtures::USER_MANAGER_CTK);
         $this->client->request(Request::METHOD_GET, '/equipment');
         $this->assertResponseIsSuccessful();
@@ -365,7 +365,7 @@ final class EquipmentControllerTest extends AbstractWebTestCase
 
     public function testIndexMgrCtkSeesOtherCtkAvailableClub(): void
     {
-        // Club G (Bretagne, Région C) a son gant disponible → CTK Île-de-France peut le voir
+        // Club G (Arc Atlantique, Région C) a son gant disponible → CTK Ile de France peut le voir
         $this->loginAs(AppFixtures::USER_MANAGER_CTK);
         $this->client->request(Request::METHOD_GET, '/equipment');
         $this->assertResponseIsSuccessful();

--- a/tests/Functional/EquipmentExportTest.php
+++ b/tests/Functional/EquipmentExportTest.php
@@ -8,7 +8,7 @@ use App\DataFixtures\AppFixtures;
 use App\Entity\Club;
 use App\Entity\Equipment;
 use App\Entity\Federation;
-use App\Entity\Glove;
+use App\Entity\Gake;
 use App\Repository\EquipmentRepository;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -26,10 +26,10 @@ use Symfony\Component\HttpFoundation\Request;
 final class EquipmentExportTest extends AbstractWebTestCase
 {
     /** ID du gant appartenant au Club A */
-    private int $gloveAId;
+    private int $gakeAId;
 
     /** ID du gant appartenant au Club G (autre CTK, disponible) */
-    private int $gloveGId;
+    private int $gakeGId;
 
     protected function setUp(): void
     {
@@ -43,14 +43,14 @@ final class EquipmentExportTest extends AbstractWebTestCase
         $equipments = $repo->findAll();
 
         foreach ($equipments as $equipment) {
-            if (!$equipment instanceof Glove) {
+            if (!$equipment instanceof Gake) {
                 continue;
             }
 
             if (AppFixtures::CLUB_A === $equipment->getOwnerClub()?->getName()) {
-                $this->gloveAId = $equipment->getId();
+                $this->gakeAId = $equipment->getId();
             } elseif (AppFixtures::CLUB_G === $equipment->getOwnerClub()?->getName()) {
-                $this->gloveGId = $equipment->getId();
+                $this->gakeGId = $equipment->getId();
             } elseif (AppFixtures::REGION_A === $equipment->getOwnerRegion()?->getName()
                 && !$equipment->getBorrowerClub() instanceof Club
                 && !$equipment->getBorrowerMember() instanceof \App\Entity\ClubMember) {
@@ -141,17 +141,17 @@ final class EquipmentExportTest extends AbstractWebTestCase
     // Filtres propagés : equipmentType
     // -----------------------------------------------------------------------
 
-    public function testExportFilterByEquipmentTypeGlove(): void
+    public function testExportFilterByEquipmentTypeGake(): void
     {
         $this->loginAs(AppFixtures::USER_ADMIN);
         $this->client->request(Request::METHOD_POST, '/equipment/export', [
-            'equipmentType' => 'glove',
+            'equipmentType' => 'gake',
         ]);
 
         $this->assertResponseIsSuccessful();
         $content = (string) $this->client->getResponse()->getContent();
 
-        // Tous les types dans un export filtré sur "glove" doivent être "Gant"
+        // Tous les types dans un export filtré sur "gake" doivent être "Gant"
         $lines = $this->parseCsvLines($content);
         $headers = array_shift($lines);
         $this->assertNotNull($headers);
@@ -164,7 +164,7 @@ final class EquipmentExportTest extends AbstractWebTestCase
                 continue;
             }
 
-            $this->assertSame('Gant (Kake)', $line[$typeIndex], 'Toutes les lignes doivent être de type Gant (Kake)');
+            $this->assertSame('Gant (Gake)', $line[$typeIndex], 'Toutes les lignes doivent être de type Gant (Gake)');
         }
     }
 
@@ -274,7 +274,7 @@ final class EquipmentExportTest extends AbstractWebTestCase
         $this->assertNotFalse($idIndex);
 
         $exportedIds = array_map(static fn (array $line): string => $line[$idIndex] ?? '', $lines);
-        $this->assertContains((string) $this->gloveAId, $exportedIds, 'Le gant du Club A doit être dans l\'export du MEMBER');
+        $this->assertContains((string) $this->gakeAId, $exportedIds, 'Le gant du Club A doit être dans l\'export du MEMBER');
     }
 
     public function testExportDoesNotContainOtherCtkEquipmentForMember(): void
@@ -291,7 +291,7 @@ final class EquipmentExportTest extends AbstractWebTestCase
         $this->assertNotFalse($idIndex);
 
         $exportedIds = array_map(static fn (array $line): string => $line[$idIndex] ?? '', $lines);
-        $this->assertNotContains((string) $this->gloveGId, $exportedIds, 'MEMBER ne doit pas voir le gant du Club G (autre CTK)');
+        $this->assertNotContains((string) $this->gakeGId, $exportedIds, 'MEMBER ne doit pas voir le gant du Club G (autre CTK)');
     }
 
     // -----------------------------------------------------------------------
@@ -300,13 +300,13 @@ final class EquipmentExportTest extends AbstractWebTestCase
 
     /**
      * Vérifie que le type dans le CSV utilise la valeur traduite par le translator
-     * (ex: "Gant (Kake)" depuis messages.fr.yaml, pas "Gant" en dur).
+     * (ex: "Gant (Gake)" depuis messages.fr.yaml, pas "Gant" en dur).
      */
     public function testExportTypeColumnUsesTranslator(): void
     {
         $this->loginAs(AppFixtures::USER_ADMIN);
         $this->client->request(Request::METHOD_POST, '/equipment/export', [
-            'equipmentType' => 'glove',
+            'equipmentType' => 'gake',
         ]);
 
         $this->assertResponseIsSuccessful();
@@ -325,9 +325,9 @@ final class EquipmentExportTest extends AbstractWebTestCase
             }
 
             $this->assertSame(
-                'Gant (Kake)',
+                'Gant (Gake)',
                 $line[$typeIndex],
-                'Le type doit utiliser la valeur traduite par le translator (messages.fr.yaml: equipment.type.glove)'
+                'Le type doit utiliser la valeur traduite par le translator (messages.fr.yaml: equipment.type.gake)'
             );
         }
     }

--- a/tests/Functional/EquipmentSearchFilterTest.php
+++ b/tests/Functional/EquipmentSearchFilterTest.php
@@ -25,11 +25,11 @@ use Symfony\Component\HttpFoundation\Request;
  *   gakeB           CLUB      Club B (Lyon)            nb_fingers=3  size=9   prêté à Club C
  *   gakeC           CLUB      Club C (Vincennes)       nb_fingers=3  size=6   disponible
  *   gakeG           CLUB      Club G (Rennes)          nb_fingers=4  size=7   disponible
- *   gakeRA          REGIONAL  Région A (Île-de-France) nb_fingers=3  size=8   disponible
- *   gakeRC          REGIONAL  Région C (Bretagne)      nb_fingers=3  size=7   disponible
+ *   gakeRA          REGIONAL  Région A (Ile de France) nb_fingers=3  size=8   disponible
+ *   gakeRC          REGIONAL  Région C (Arc Atlantique) nb_fingers=3  size=7   disponible
  *   gakeNat         NATIONAL  Fédération               nb_fingers=5  size=10  disponible
  *   gakeNatBorrowed NATIONAL  Fédération               nb_fingers=3  size=8   prêté à memberLinked
- *   gakeRegABorrowed REGIONAL Région A (Île-de-France) nb_fingers=4  size=7   prêté à Club A
+ *   gakeRegABorrowed REGIONAL Région A (Ile de France) nb_fingers=4  size=7   prêté à Club A
  *
  * Arcs (9) :
  *   yumiA1   CLUB      Club A  bambou       14  namisun      disponible
@@ -189,7 +189,7 @@ final class EquipmentSearchFilterTest extends AbstractWebTestCase
     // -----------------------------------------------------------------------
     // E. Filtre status=loaned
     // Admin : gakeB + yumiD + gakeNatBorrowed + gakeRegABorrowed → LOANED_COUNT=4.
-    // Member (Club A / Île-de-France) : ne voit que son club + régional dispo →
+    // Member (Club A / Ile de France) : ne voit que son club + régional dispo →
     //   Club A n'a aucun équipement prêté → 0 résultat.
     // -----------------------------------------------------------------------
 

--- a/tests/Functional/UserControllerTest.php
+++ b/tests/Functional/UserControllerTest.php
@@ -152,6 +152,32 @@ final class UserControllerTest extends AbstractWebTestCase
         $this->assertGetGranted('/user');
     }
 
+    public function testCreateUserButtonVisibleForAdmin(): void
+    {
+        $this->loginAs(AppFixtures::USER_ADMIN);
+        $crawler = $this->client->request(Request::METHOD_GET, '/user');
+        $this->assertResponseStatusCodeSame(200);
+
+        // Vérifier que le bouton "Créer un utilisateur" est visible
+        $link = $crawler->selectLink('Créer un utilisateur');
+        $this->assertCount(1, $link, 'Le bouton "Créer un utilisateur" doit être visible pour l\'admin');
+
+        // Vérifier que le lien pointe vers la route admin_user_create
+        $href = $link->attr('href');
+        $this->assertStringContainsString('/admin/users/create', (string) $href);
+    }
+
+    public function testCreateUserButtonHiddenForNonAdmin(): void
+    {
+        $this->loginAs(AppFixtures::USER_PRESIDENT);
+        $crawler = $this->client->request(Request::METHOD_GET, '/user');
+        $this->assertResponseStatusCodeSame(200);
+
+        // Vérifier que le bouton "Créer un utilisateur" n'est pas visible
+        $link = $crawler->selectLink('Créer un utilisateur');
+        $this->assertCount(0, $link, 'Le bouton "Créer un utilisateur" ne doit pas être visible pour un non-admin');
+    }
+
     // -----------------------------------------------------------------------
     // GET /user/{id}/club — assignation d'un club
     // Autorisé pour : CLUB_PRESIDENT, EQUIPMENT_MANAGER_CTK, ADMIN


### PR DESCRIPTION
- Ajout de données dans les fixtures
- corrections de quelques bugs résiduel lié au changement Glove => Gake
- ajout de la possibilité pour l'admin de créer un user. Quand il se connectera avec son email et le mot de passe fournit il sera redirigé vers une page qui le force à créer un nouveau mot de passe
