### PR TITLE
Prendre en charge les tailles alphanumériques

### DIFF
--- a/migrations/Version20260725114156.php
+++ b/migrations/Version20260725114156.php
@@ -19,14 +19,11 @@ final class Version20260725114156 extends AbstractMigration
 
     public function up(Schema $schema): void
     {
-        // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE equipment ALTER size TYPE VARCHAR(255)');
     }
 
     public function down(Schema $schema): void
     {
-        // this down() migration is auto-generated, please modify it to your needs
-        $this->addSql('CREATE SCHEMA public');
         $this->addSql('ALTER TABLE equipment ALTER size TYPE INT');
     }
 }

--- a/migrations/Version20260725114156.php
+++ b/migrations/Version20260725114156.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260725114156 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE equipment ALTER size TYPE VARCHAR(255)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE equipment ALTER size TYPE INT');
+    }
+}

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -453,20 +453,20 @@ class AppFixtures extends Fixture
         $gakeA1 = new Gake()
             ->setOwnerClub($clubA)
             ->setNbFingers(3)
-            ->setSize(8);
+            ->setSize('8');
         $manager->persist($gakeA1);
 
         $gakeA2 = new Gake()
             ->setOwnerClub($clubA)
             ->setNbFingers(3)
-            ->setSize(7);
+            ->setSize('7');
         $manager->persist($gakeA2);
 
         // CLUB — Club B (Lyon) — avec emprunteur club (Vincennes emprunte à Lyon)
         $gakeB = new Gake()
             ->setOwnerClub($clubB)
             ->setNbFingers(3)
-            ->setSize(9)
+            ->setSize('9')
             ->setBorrowerClub($clubC);
         $manager->persist($gakeB);
 
@@ -474,14 +474,14 @@ class AppFixtures extends Fixture
         $gakeC = new Gake()
             ->setOwnerClub($clubC)
             ->setNbFingers(3)
-            ->setSize(6);
+            ->setSize('6');
         $manager->persist($gakeC);
 
         // CLUB — Club G (Rennes)
         $gakeG = new Gake()
             ->setOwnerClub($clubG)
             ->setNbFingers(4)
-            ->setSize(7);
+            ->setSize('L');
         $manager->persist($gakeG);
 
         // REGIONAL — Région A (Ile de France)
@@ -489,7 +489,7 @@ class AppFixtures extends Fixture
             ->setOwnerRegion($regionA)
             ->setEquipmentLevel(EquipmentLevel::REGIONAL)
             ->setNbFingers(3)
-            ->setSize(8);
+            ->setSize('8');
         $manager->persist($gakeRegA);
 
         // REGIONAL — Région C (Arc Atlantique)
@@ -497,7 +497,7 @@ class AppFixtures extends Fixture
             ->setOwnerRegion($regionC)
             ->setEquipmentLevel(EquipmentLevel::REGIONAL)
             ->setNbFingers(3)
-            ->setSize(7);
+            ->setSize('7');
         $manager->persist($gakeRegC);
 
         // NATIONAL
@@ -505,7 +505,7 @@ class AppFixtures extends Fixture
             ->setOwnerFederation($federation)
             ->setEquipmentLevel(EquipmentLevel::NATIONAL)
             ->setNbFingers(5)
-            ->setSize(10);
+            ->setSize('10');
         $manager->persist($gakeNat);
 
         // NATIONAL — emprunté (pour tester la restriction "dispo seulement" des rôles < CN)
@@ -513,7 +513,7 @@ class AppFixtures extends Fixture
             ->setOwnerFederation($federation)
             ->setEquipmentLevel(EquipmentLevel::NATIONAL)
             ->setNbFingers(3)
-            ->setSize(8)
+            ->setSize('8')
             ->setBorrowerMember($memberLinked);
         $manager->persist($gakeNatBorrowed);
 
@@ -523,7 +523,7 @@ class AppFixtures extends Fixture
             ->setOwnerRegion($regionA)
             ->setEquipmentLevel(EquipmentLevel::REGIONAL)
             ->setNbFingers(4)
-            ->setSize(7)
+            ->setSize('7')
             ->setBorrowerClub($clubA);
         $manager->persist($gakeRegABorrowed);
 

--- a/src/Entity/Gake.php
+++ b/src/Entity/Gake.php
@@ -18,7 +18,7 @@ class Gake extends Equipment
 
     #[ORM\Column(nullable: true)]
     #[Versioned]
-    private ?int $size = null;
+    private ?string $size = null;
 
     public static function getType(): EquipmentType
     {
@@ -37,12 +37,12 @@ class Gake extends Equipment
         return $this;
     }
 
-    public function getSize(): ?int
+    public function getSize(): ?string
     {
         return $this->size;
     }
 
-    public function setSize(?int $size): static
+    public function setSize(?string $size): static
     {
         $this->size = $size;
 

--- a/src/Factory/GakeFactory.php
+++ b/src/Factory/GakeFactory.php
@@ -18,13 +18,13 @@ final class GakeFactory extends PersistentProxyObjectFactory
     }
 
     /**
-     * @return array<string, int>
+     * @return array<string, int|string>
      */
     protected function defaults(): array
     {
         return [
             'nb_fingers' => self::faker()->numberBetween(3, 5),
-            'size' => self::faker()->numberBetween(6, 12),
+            'size' => (string) self::faker()->numberBetween(6, 12),
         ];
     }
 

--- a/src/Form/GakeFormType.php
+++ b/src/Form/GakeFormType.php
@@ -7,8 +7,10 @@ namespace App\Form;
 use App\Entity\Gake;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
 use Symfony\Component\Validator\Constraints\Range;
 
 /**
@@ -26,21 +28,16 @@ class GakeFormType extends AbstractType
                 ],
                 'required' => true,
             ])
-            ->add('size', IntegerType::class, [
+            ->add('size', TextType::class, [
                 'label' => 'Taille',
                 'constraints' => [
-                    new Range(
-                        notInRangeMessage: 'La taille doit être entre 3 et 11',
-                        min: 3,
-                        max: 11,
-                    ),
+                    new Length(max: 255),
+                ],
+                'attr' => [
+                    'maxlength' => 255,
+                    'placeholder' => 'Nombre ou S/M/L',
                 ],
                 'required' => false,
-                'attr' => [
-                    'min' => 3,
-                    'max' => 11,
-                    'placeholder' => 'Entre 3 et 11',
-                ],
             ]);
     }
 

--- a/src/Service/EquipmentExportService.php
+++ b/src/Service/EquipmentExportService.php
@@ -259,7 +259,7 @@ final readonly class EquipmentExportService
     private function extractSize(Equipment $equipment): string
     {
         if ($equipment instanceof Gake) {
-            return (string) ($equipment->getSize() ?? '');
+            return $equipment->getSize() ?? '';
         }
 
         if ($equipment instanceof Muneate) {


### PR DESCRIPTION
Remplacement du type `int` par `string` pour le champ `size` afin de permettre les tailles numériques et alphanumériques (S, M, L, XL, etc.).