### PR TITLE
Afficher les e-mails des gestionnaires matériel 

### DIFF
--- a/templates/club/index.html.twig
+++ b/templates/club/index.html.twig
@@ -69,7 +69,7 @@
 									<div class="flex items-start justify-between gap-3">
 										<div class="min-w-0">
 											<h2 class="truncate text-base font-semibold text-kyudo-gm-dark">{{ club.name }}</h2>
-											<p class="mt-1 text-xs text-kyudo-gm-grey">Président.e :
+											<p class="mt-1 text-xs text-kyudo-gm-grey">Président·e  :
 												{{ club.president ? club.president : '-' }}</p>
 											<p class="mt-1 text-xs text-kyudo-gm-grey">Gestionnaire matériel :
 												{{ club.equipmentManager ? club.equipmentManager : '-' }}</p>
@@ -113,7 +113,7 @@
 									<tr>
 										<th class="px-5 py-4">ID</th>
 										<th class="px-5 py-4">Nom</th>
-										<th class="px-5 py-4">Président</th>
+										<th class="px-5 py-4">Président·e</th>
 										<th class="px-5 py-4">Gestionnaire matériel</th>
 										<th class="px-5 py-4">Email</th>
 										<th class="px-5 py-4 text-center">Actions</th>

--- a/templates/club/index.html.twig
+++ b/templates/club/index.html.twig
@@ -69,8 +69,10 @@
 									<div class="flex items-start justify-between gap-3">
 										<div class="min-w-0">
 											<h2 class="truncate text-base font-semibold text-kyudo-gm-dark">{{ club.name }}</h2>
-											<p class="mt-1 text-xs text-kyudo-gm-grey">Président :
+											<p class="mt-1 text-xs text-kyudo-gm-grey">Président.e :
 												{{ club.president ? club.president : '-' }}</p>
+											<p class="mt-1 text-xs text-kyudo-gm-grey">Gestionnaire matériel :
+												{{ club.equipmentManager ? club.equipmentManager : '-' }}</p>
 											<p class="mt-2 text-xs text-kyudo-gm-dark">
 												{% if club.email %}
 													<a class="text-blue-700 hover:underline" href="mailto:{{ club.email }}">{{ club.email }}</a>
@@ -112,8 +114,9 @@
 										<th class="px-5 py-4">ID</th>
 										<th class="px-5 py-4">Nom</th>
 										<th class="px-5 py-4">Président</th>
+										<th class="px-5 py-4">Gestionnaire matériel</th>
 										<th class="px-5 py-4">Email</th>
-										<th class="px-5 py-4 text-right">Actions</th>
+										<th class="px-5 py-4 text-center">Actions</th>
 									</tr>
 								</thead>
 								<tbody class="divide-y divide-kyudo-gm-light-grey text-sm">
@@ -121,7 +124,20 @@
 										<tr class="hover:bg-kyudo-gm-light-grey">
 											<td class="px-5 py-4 text-kyudo-gm-grey">{{ club.id }}</td>
 											<td class="px-5 py-4 font-semibold text-kyudo-gm-dark">{{ club.name }}</td>
-											<td class="px-5 py-4 text-kyudo-gm-dark">{{ club.president ? club.president : '-' }}</td>
+											<td class="px-5 py-4">
+												{% if club.president %}
+													<a class="text-kyudo-gm-dark hover:text-blue-700" href="mailto:{{ club.president }}">{{ club.president.email }}</a>
+												{% else %}
+													<span class="text-">-</span>
+												{% endif %}
+											</td>
+											<td class="px-5 py-4">
+												{% if club.equipmentManager %}
+													<a class="text-kyudo-gm-dark hover:text-blue-700" href="mailto:{{ club.equipmentManager }}">{{ club.equipmentManager.email }}</a>
+												{% else %}
+													<span class="text-">-</span>
+												{% endif %}
+											</td>
 											<td class="px-5 py-4">
 												{% if club.email %}
 													<a class="text-kyudo-gm-dark hover:text-blue-700" href="mailto:{{ club.email }}">{{ club.email }}</a>

--- a/templates/club/show.html.twig
+++ b/templates/club/show.html.twig
@@ -41,7 +41,7 @@
 						<div class="rounded-2xl bg-kyudo-gm-light-grey p-4">
 							<div class="flex items-center gap-2">
 								<dt class="text-xs font-medium text-kyudo-gm-dark">
-									Président.e :
+									Président·e :
 								</dt>
 							</div>
 

--- a/templates/club/show.html.twig
+++ b/templates/club/show.html.twig
@@ -39,15 +39,35 @@
 
 					<dl class="mt-4 grid gap-4 sm:grid-cols-2">
 						<div class="rounded-2xl bg-kyudo-gm-light-grey p-4">
-							<dt class="text-xs font-medium text-">ID</dt>
-							<dd class="mt-1 text-sm font-semibold text-kyudo-gm-dark">{{ club.id }}</dd>
+							<div class="flex items-center gap-2">
+								<dt class="text-xs font-medium text-kyudo-gm-dark">
+									Président.e :
+								</dt>
+							</div>
+
+							{% if club.president %}
+								<dd class="mt-1 text-sm text-kyudo-gm-dark">
+									<a href="mailto:{{ club.president.email }}" class="hover:underline">
+										{{ club.president.email }}
+									</a>
+								</dd>
+							{% endif %}
 						</div>
 
 						<div class="rounded-2xl bg-kyudo-gm-light-grey p-4">
-							<dt class="text-xs font-medium text-">Président</dt>
-							<dd class="mt-1 text-sm font-semibold text-kyudo-gm-dark">
-								{{ club.president ? club.president.fullName : '-' }}
-							</dd>
+							<div class="flex items-center gap-2">
+								<dt class="text-xs font-medium text-kyudo-gm-dark">
+									Gestionnaire matériel :
+								</dt>
+							</div>
+
+							{% if club.equipmentManager %}
+								<dd class="mt-1 text-sm text-kyudo-gm-dark">
+									<a href="mailto:{{ club.equipmentManager.email }}" class="hover:underline">
+										{{ club.equipmentManager.email }}
+									</a>
+								</dd>
+							{% endif %}
 						</div>
 
 						<div class="rounded-2xl bg-kyudo-gm-light-grey p-4 sm:col-span-2">


### PR DESCRIPTION
- Ajout de l'adresse e-mail du gestionnaire matériel dans les aperçus des clubs (cartes et tableau).
- Suppression de l'affichage des id sur les fiches des clubs, car ils n'apportent pas d'information utile aux utilisateurs.
- Les adresses e-mail des président·e·s sont désormais cliquables.
- Ajout de l'écriture inclusive (président·e)